### PR TITLE
build(arch): make OCR optional + ship Arch deps installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,16 @@
 name: Release
 
-# Tag `vX.Y.Z` → build platform artifacts → publish a GitHub Release.
+# Tag `vX.Y.Z` → build platform artifacts → publish a GitHub Release →
+# push `opal` + `opal-bin` PKGBUILDs to AUR.
 #
 # Coverage today:
 #   • macos-arm64    — Opal.app bundle (zip) + bare binary tarball    [primary]
 #   • linux-x86_64   — binary tarball + .deb + .rpm + AppImage + .run [best-effort]
 #   • windows-x86_64 — portable .zip + .msi (MSYS2/MINGW64 build +
 #                      vendored MS onnxruntime; see the job for why)  [experimental]
+#   • aur            — opal (source from release tarball) + opal-bin  [gated]
+#                      (binary tarball repackage); gated on
+#                      AUR_PUBLISH_ENABLED='true' + AUR_SSH_PRIVATE_KEY secret.
 #
 # Not covered: macos-x86_64 (GitHub retired the free Intel runner images —
 # macos-13 queues forever; Intel Mac users build from source, where build.zig
@@ -454,3 +458,24 @@ jobs:
             artifacts/SHA256SUMS.txt
           generate_release_notes: true
           draft: false
+
+  # ── AUR publish ─────────────────────────────────────────────────────────
+  # Auto-updates `opal` (source build from the release tarball) and `opal-bin`
+  # (repackage the official binary tarball) on every vX.Y.Z tag. Skipped until
+  # the `AUR_SSH_PRIVATE_KEY` repo secret is set; this lets the rest of the
+  # release ship even before AUR is wired up.
+  aur:
+    needs: publish
+    runs-on: ubuntu-24.04
+    if: ${{ vars.AUR_PUBLISH_ENABLED == 'true' && secrets.AUR_SSH_PRIVATE_KEY != '' }}
+    steps:
+      - uses: actions/checkout@v4
+      #pacman-contrib isn't on Ubuntu; we set AUR_SKIP_MAKEPKG=1 since the
+      #separate ci.yml Arch job covers the build-proof.
+      - name: Push PKGBUILDs to AUR
+        env:
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          AUR_USERNAME: ${{ vars.AUR_USERNAME }}
+          AUR_EMAIL: ${{ vars.AUR_EMAIL }}
+          AUR_SKIP_MAKEPKG: "1"
+        run: ./packaging/aur/push-to-aur.sh

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -35,7 +35,9 @@ source=()
 sha256sums=()
 
 # ── Build from local source (for local installs) ──
-# When publishing to AUR, replace this with proper git source
+# When publishing to AUR, replace source=() with a git tag/tarball.
+# OCR (onnxruntime-cpu) is OFF by default — optdepends line above lists the
+# extra runtime dep; build with `zig build -Docr=true` to enable it.
 
 build() {
     cd "${startdir}"
@@ -47,10 +49,12 @@ build() {
         -o libtorrent_wrapper.so \
         -ltorrent-rasterbar
 
-    # 2. Build the Zig binary
-    echo "==> Building opal with zig build..."
-    zig build -Doptimize=ReleaseSafe 2>&1 || true
-    # The "error: warning(link)" from LLD is cosmetic — binary is produced
+    # 2. Build the Zig binary. `-fsys=sdl2` links the SYSTEM SDL2 (sdl2-compat
+    #    / SDL3) instead of dvui's bundled static SDL2 — the bundled one has
+    #    archive members that trip LLD's "neither ET_REL nor LLVM bitcode"
+    #    warnings into errors under zig 0.16, blocking the build entirely.
+    echo "==> Building opal (ReleaseSafe) with system SDL2..."
+    zig build -fsys=sdl2 -Doptimize=ReleaseSafe
 
     if [ ! -f zig-out/bin/opal ]; then
         echo "ERROR: zig build failed — no binary produced"
@@ -78,16 +82,38 @@ package() {
     # ── Camoufox bridge (stealth browser) ──
     install -Dm755 scripts/camoufox_bridge.py "${instdir}/camoufox_bridge.py"
 
-    # ── Launcher script (sets up library paths) ──
+    # ── Dep installer (lets users repair missing runtime deps post-install) ──
+    install -Dm755 scripts/install-deps.sh "${instdir}/install-deps.sh"
+
+    # ── Launcher script (sets up library paths, hints at deps self-repair) ──
     install -dm755 "${bindir}"
     cat > "${pkgdir}/usr/bin/opal" << 'LAUNCHER'
 #!/bin/bash
-# Opal launcher — sets library paths for bundled .so files
-export LD_LIBRARY_PATH="/opt/opal${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+# Opal launcher — auto-detect missing system libs and point users to the
+# bundled repair script, then run the app.
 export OPAL_HOME="/opt/opal"
+export LD_LIBRARY_PATH="/opt/opal${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export PATH="/opt/opal:$PATH"
 
 # Ensure user config directory
 mkdir -p "${XDG_CONFIG_HOME:-$HOME/.config}/opal"
+
+# Probe for missing runtime libs/bins (one-shot, ~5ms).
+missing=0
+ld_cache="$(ldconfig -p 2>/dev/null || true)"
+for soname in libSDL2-2.0.so.0 libmpv.so.2 libsqlite3.so.0 libtorrent-rasterbar.so.2.0; do
+    if [[ "$ld_cache" != *"$soname"* ]]; then missing=1; break; fi
+done
+if [[ "$missing" -eq 0 ]]; then
+    for bin in mpv ffmpeg yt-dlp curl; do
+        command -v "$bin" >/dev/null 2>&1 || { missing=1; break; }
+    done
+fi
+if [[ "$missing" -eq 1 ]]; then
+    echo "Opal: missing system libraries/binary detected." >&2
+    echo "  Repair with: sudo /opt/opal/install-deps.sh" >&2
+    echo "  Or install manually — see PKGBUILD optdepends/depends list." >&2
+fi
 
 exec /opt/opal/opal "$@"
 LAUNCHER

--- a/build.zig
+++ b/build.zig
@@ -148,36 +148,47 @@ pub fn build(b: *std.Build) void {
         exe.headerpad_max_install_names = true;
     }
 
-    // OCR via ONNX Runtime (PP-OCR pipeline)
-    exe.root_module.addCSourceFile(.{
-        .file = b.path("ort/ocr_ort.c"),
-        .flags = &[_][]const u8{ "-O2", "-Wno-unused-result" },
-    });
-    exe.root_module.addIncludePath(b.path("ort"));
-    exe.root_module.addLibraryPath(b.path("ort"));
-    if (is_windows) {
-        // ONNXRUNTIME_DIR: root of a vendored Microsoft onnxruntime release
-        // (github.com/microsoft/onnxruntime, onnxruntime-win-x64-<ver>.zip —
-        // include/*.h + lib/onnxruntime.{lib,dll}). MSYS2 has no onnxruntime
-        // package for the MINGW64 environment, and the UCRT64 one links a
-        // different CRT than zig's x86_64-windows-gnu output — mixing them is
-        // what produced the "entry point strtod could not be located" launch
-        // failure in v0.1.0 (issue #3). The MS build is MSVC-compiled but
-        // exposes a pure C ABI, and its onnxruntime.lib is a plain COFF
-        // import lib that zig's lld links fine from the gnu target.
-        if (b.graph.environ_map.get("ONNXRUNTIME_DIR")) |ort_dir| {
-            exe.root_module.addIncludePath(.{ .cwd_relative = b.fmt("{s}/include", .{ort_dir}) });
-            exe.root_module.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/onnxruntime.lib", .{ort_dir}) });
+    // OCR via ONNX Runtime (PP-OCR pipeline) — optional, gated by -Docr.
+    // Default off: onnxruntime isn't a standard Arch/Debian package and the
+    // manga/video frame OCR features are only used by a subset of users.
+    // Build with `-Docr=true` to enable (requires `onnxruntime` installed:
+    // Arch: `pacman -S onnxruntime-cpu`, macOS: `brew install onnxruntime`).
+    const enable_ocr = b.option(bool, "ocr", "Enable OCR via ONNX Runtime (default: auto-detect)") orelse false;
+    if (enable_ocr) {
+        exe.root_module.addCSourceFile(.{
+            .file = b.path("ort/ocr_ort.c"),
+            .flags = &[_][]const u8{ "-O2", "-Wno-unused-result" },
+        });
+        exe.root_module.addIncludePath(b.path("ort"));
+        exe.root_module.addLibraryPath(b.path("ort"));
+        if (is_windows) {
+            // ONNXRUNTIME_DIR: root of a vendored Microsoft onnxruntime release
+            // (github.com/microsoft/onnxruntime, onnxruntime-win-x64-<ver>.zip —
+            // include/*.h + lib/onnxruntime.{lib,dll}). MSYS2 has no onnxruntime
+            // package for the MINGW64 environment, and the UCRT64 one links a
+            // different CRT than zig's x86_64-windows-gnu output — mixing them is
+            // what produced the "entry point strtod could not be located" launch
+            // failure in v0.1.0 (issue #3). The MS build is MSVC-compiled but
+            // exposes a pure C ABI, and its onnxruntime.lib is a plain COFF
+            // import lib that zig's lld links fine from the gnu target.
+            if (b.graph.environ_map.get("ONNXRUNTIME_DIR")) |ort_dir| {
+                exe.root_module.addIncludePath(.{ .cwd_relative = b.fmt("{s}/include", .{ort_dir}) });
+                exe.root_module.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/onnxruntime.lib", .{ort_dir}) });
+            } else {
+                // No vendored dir: fall back to a MinGW-built import lib under
+                // MINGW_PREFIX for anyone who has one (see the mpv/sqlite3 note
+                // above on why .dll.a needs addObjectFile).
+                exe.root_module.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libonnxruntime.dll.a", .{mingw_prefix}) });
+            }
         } else {
-            // No vendored dir: fall back to a MinGW-built import lib under
-            // MINGW_PREFIX for anyone who has one (see the mpv/sqlite3 note
-            // above on why .dll.a needs addObjectFile).
-            exe.root_module.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libonnxruntime.dll.a", .{mingw_prefix}) });
+            exe.root_module.linkSystemLibrary("onnxruntime", .{});
+            exe.root_module.addRPath(b.path("ort"));
         }
-    } else {
-        exe.root_module.linkSystemLibrary("onnxruntime", .{});
-        exe.root_module.addRPath(b.path("ort"));
     }
+    // Surface OCR availability to the app source via `@import("ocr_build_options")`.
+    const ocr_build_options = b.addOptions();
+    ocr_build_options.addOption(bool, "has_ocr", enable_ocr);
+    exe.root_module.addOptions("ocr_build_options", ocr_build_options);
 
     exe.root_module.addIncludePath(b.path("src"));
 

--- a/packaging/aur/push-to-aur.sh
+++ b/packaging/aur/push-to-aur.sh
@@ -1,32 +1,83 @@
 #!/usr/bin/env bash
 # Publish/refresh the AUR packages (opal, opal-bin).
 #
-# Run ON AN ARCH BOX (needs makepkg + updpkgsums from pacman-contrib), with an
-# AUR account whose SSH key is configured (https://wiki.archlinux.org/title/AUR).
-# The repo must be PUBLIC first — the source/release URLs 404 while private.
+# Two modes:
 #
-#   ./push-to-aur.sh            # both packages
-#   ./push-to-aur.sh opal-bin   # just one
+# 1) Local Arch box (interactive, for first-time bootstrap):
+#      ./push-to-aur.sh                # both packages
+#      ./push-to-aur.sh opal-bin       # just one
+#    Requires: an AUR account with your SSH key registered, `pacman-contrib`
+#    (for updpkgsums), `pkgconf`. Run on an Arch host so `makepkg -f` proves
+#    the build actually works before pushing.
+#
+# 2) CI (GitHub Actions release.yml, non-interactive): set
+#      AUR_SSH_PRIVATE_KEY  — ed25519 private key whose pubkey is registered
+#                            on the AUR account
+#      AUR_USERNAME         — AUR username (used for git commit identity only)
+#      AUR_EMAIL            — AUR email   (used for git commit identity only)
+#      AUR_SKIP_MAKEPKG=1   — skip the `makepkg -f` build-verification step
+#                            (CI runners for the release job are Ubuntu; the
+#                            Arch-only deps would have to be installed there.
+#                            The native Arch job in ci.yml covers build-proof
+#                            separately; AUR publish just needs the metadata.)
+#    Then:
+#      AUR_SSH_PRIVATE_KEY=… AUR_USERNAME=… AUR_EMAIL=… \
+#        AUR_SKIP_MAKEPKG=1 ./push-to-aur.sh
 set -euo pipefail
 cd "$(dirname "$0")"
 
 PKGS=("${@:-opal opal-bin}")
 
-for pkg in ${PKGS[@]}; do
-    echo "── $pkg ──"
-    workdir=$(mktemp -d)
-    # AUR repo (empty on first publish — pushing creates the package).
-    git clone "ssh://aur@aur.archlinux.org/${pkg}.git" "$workdir"
-    cp "$pkg/PKGBUILD" "$workdir/"
-    pushd "$workdir" >/dev/null
-    updpkgsums                                    # fill sha256sums from the live URLs
-    makepkg --printsrcinfo > .SRCINFO             # AUR requires it in sync
-    makepkg -f --noconfirm                        # prove it actually builds before pushing
-    git add PKGBUILD .SRCINFO
-    git commit -m "$(grep -oP '^pkgver=\K.*' PKGBUILD)-$(grep -oP '^pkgrel=\K.*' PKGBUILD)"
-    git push origin master
-    popd >/dev/null
+# ─── CI mode: materialise the SSH key + identity into a sandbox ──────────
+if [[ -n "${AUR_SSH_PRIVATE_KEY:-}" ]]; then
+  : "${AUR_USERNAME:?AUR_USERNAME required in CI mode}"
+  : "${AUR_EMAIL:?AUR_EMAIL required in CI mode}"
+  export GIT_SSH_COMMAND="ssh -i $HOME/.aur_id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+  printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > "$HOME/.aur_id_ed25519"
+  chmod 600 "$HOME/.aur_id_ed25519"
+  ssh-keyscan -t ed25519 aur.archlinux.org >> "$HOME/.aur_known_hosts" 2>/dev/null || true
+  export GIT_SSH_COMMAND="ssh -i $HOME/.aur_id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=$HOME/.aur_known_hosts"
+  export GIT_AUTHOR_NAME="$AUR_USERNAME"  GIT_AUTHOR_EMAIL="$AUR_EMAIL"
+  export GIT_COMMITTER_NAME="$AUR_USERNAME" GIT_COMMITTER_EMAIL="$AUR_EMAIL"
+fi
+
+skip_makepkg=0
+[[ "${AUR_SKIP_MAKEPKG:-0}" == "1" ]] && skip_makepkg=1
+
+for pkg in "${PKGS[@]}"; do
+  echo "── $pkg ──"
+  workdir=$(mktemp -d)
+  # AUR repo (empty on first publish — pushing creates the package).
+  if ! git clone "ssh://aur@aur.archlinux.org/${pkg}.git" "$workdir"; then
+    # First-time publish: the repo doesn't exist yet on AUR. `git clone`
+    # against an empty AUR namespace returns an empty repo with exit 0;
+    # if it actually failed (e.g. permission denied), surface that clearly.
+    echo "error: clone of aur:${pkg} failed — does the AUR account own that namespace?"
     rm -rf "$workdir"
-    echo "✓ $pkg pushed"
+    exit 1
+  fi
+  cp "$pkg/PKGBUILD" "$workdir/"
+  pushd "$workdir" >/dev/null
+  # Fill sha256sums from the live URLs (now that the tag is public). On an
+  # Arch host this Just Works; on the CI Ubuntu runner we skip (sources
+  # aren't downloadable until the release artifacts are uploaded, and we
+  # don't want to require Arch toolchain there).
+  if command -v updpkgsums >/dev/null 2>&1; then
+    updpkgsums
+  else
+    echo "warn: updpkgsums missing — keeping 'SKIP' checksums (AUR will reject if URL hashes mismatch)"
+  fi
+  makepkg --printsrcinfo > .SRCINFO             # AUR requires .SRCINFO in sync
+  if [[ "$skip_makepkg" -eq 0 ]] && command -v makepkg >/dev/null 2>&1; then
+    makepkg -f --noconfirm                        # prove it builds before pushing
+  fi
+  git add PKGBUILD .SRCINFO
+  # Empty git tree (first publish) — git refuses to commit "nothing changed"
+  # when the index equals HEAD. Explicitly allow empty.
+  git commit --allow-empty -m "$(grep -oP '^pkgver=\K.*' PKGBUILD)-$(grep -oP '^pkgrel=\K.*' PKGBUILD) [ci publish]"
+  git push origin master
+  popd >/dev/null
+  rm -rf "$workdir"
+  echo "✓ $pkg pushed"
 done
 echo "Done. yay -S opal (or opal-bin) should now resolve."

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Ensure the host has the system dependencies Opal needs at build and runtime.
+# Detects the distro family and installs the matching packages.
+#
+# Usage:
+#   ./scripts/install-deps.sh             # install (asks for sudo if needed)
+#   ./scripts/install-deps.sh --check      # exit 0 if all present, 1 if missing
+#
+# The package list mirrors PKGBUILD depends/makedepends/optdepends. Note that
+# OCR (ONNX Runtime) is OPTIONAL — `zig build -Docr=true` enables it. Without
+# -Docr, opal builds and runs without onnxruntime.
+set -euo pipefail
+
+check_only=0
+[[ "${1:-}" == "--check" ]] && check_only=1
+
+# ─── Distribution detection ───────────────────────────────────────────────
+detect_distro() {
+  [[ -r /etc/os-release ]] || { echo unknown; return; }
+  . /etc/os-release
+  case "${ID:-}:${ID_LIKE:-}" in
+    arch*|manjaro*|cachyos*|endeavouros*|garuda*|*:arch*) echo arch ;;
+    debian*|ubuntu*|linuxmint*|pop*|*:debian*)            echo debian ;;
+    fedora*|rhel*|rocky*|alma*|*:rhel*)                   echo fedora ;;
+    opensuse*|suse*)                                     echo suse ;;
+    *) case "${ID:-}" in
+         nixos)  echo nixos ;;
+         alpine) echo alpine ;;
+         void)   echo void ;;
+         gentoo) echo gentoo ;;
+         *)      echo unknown ;;
+       esac ;;
+  esac
+}
+
+# ─── Per-distro packages ──────────────────────────────────────────────────
+# build: needed to compile; runtime: needed to run; optional: nice-to-have.
+declare_arch_build=("zig>=0.15.2" gcc git)
+declare_arch_runtime=(mpv sdl2 sqlite libtorrent-rasterbar curl python python-pip ffmpeg yt-dlp)
+declare_arch_optional=(streamlink "onnxruntime-cpu: OCR (build with -Docr=true)")
+
+declare_debian_build=(zig gcc git pkg-config)
+declare_debian_runtime=(mpv libsdl2-2.0-0 libsqlite3-0 libtorrent-rasterbar curl python3 python3-pip ffmpeg yt-dlp)
+declare_debian_optional=(streamlink)
+
+declare_fedora_build=(zig gcc git pkg-config)
+declare_fedora_runtime=(mpv SDL2 sqlite libtorrent-rasterbar curl python3 python3-pip ffmpeg yt-dlp)
+declare_fedora_optional=()
+
+declare_suse_build=(zig gcc git pkg-config)
+declare_suse_runtime=(mpv libSDL2-2_0-0 libsqlite3-0 libtorrent-rasterbar curl python3 python3-pip ffmpeg yt-dlp)
+declare_suse_optional=()
+
+# Distro-agnostic runtime probes (ldconfig for .so, $PATH for binaries)
+declare -A RUNTIME_LIBS=(
+  [libSDL2]="libSDL2-2.0.so.0"
+  [libmpv]="libmpv.so.2"
+  [libsqlite3]="libsqlite3.so.0"
+  [libtorrent-rasterbar]="libtorrent-rasterbar.so.2.0"
+)
+declare -a RUNTIME_BINS=(mpv curl python3 pip3 ffmpeg yt-dlp)
+declare -a BUILD_BINS=(zig gcc git)
+
+list_missing() {
+  local missing=()
+  local ld_cache
+  ld_cache="$(ldconfig -p 2>/dev/null || true)"
+  for soname in "${RUNTIME_LIBS[@]}"; do
+    [[ "$ld_cache" != *"$soname"* ]] && missing+=("$soname")
+  done
+  for bin in "${RUNTIME_BINS[@]}" "${BUILD_BINS[@]}"; do
+    command -v "$bin" >/dev/null 2>&1 || missing+=("$bin")
+  done
+  printf '%s\n' "${missing[@]}"
+}
+
+distro="$(detect_distro)"
+
+if [[ "$check_only" -eq 1 ]]; then
+  rc=0
+  missing=()
+  while read -r m; do [[ -n "$m" ]] && missing+=("$m"); done < <(list_missing)
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    echo "missing: ${missing[*]}"
+    rc=1
+  fi
+  exit $rc
+fi
+
+_sudo() { if [[ $EUID -eq 0 ]]; then "$@"; else sudo "$@"; fi; }
+
+install_arch() {
+  local aur=""
+  for h in yay paru; do command -v "$h" >/dev/null 2>&1 && aur="$h" && break; done
+  echo "==> [arch] build deps: ${declare_arch_build[*]}"
+  _sudo pacman -S --needed --noconfirm "${declare_arch_build[@]}" || echo "warn: some build deps failed to install"
+  echo "==> [arch] runtime deps: ${declare_arch_runtime[*]}"
+  _sudo pacman -S --needed --noconfirm "${declare_arch_runtime[@]}" || echo "warn: some runtime deps failed to install"
+  # Optional: streamlink is in community
+  pacman -S --needed --noconfirm streamlink 2>/dev/null || true
+  # Optional: OCR via onnxruntime-cpu (only needed for `zig build -Docr=true`)
+  pacman -S --needed --noconfirm onnxruntime-cpu 2>/dev/null || true
+  # camoufox isn't packaged — pip install
+  pip3 install --user --break-system-packages camoufox 2>/dev/null || true
+}
+
+install_debian() {
+  echo "==> [debian] build deps"
+  _sudo apt-get update -y
+  _sudo apt-get install -y --no-install-recommends "${declare_debian_build[@]}" || echo "warn: some build deps failed"
+  echo "==> [debian] runtime deps"
+  _sudo apt-get install -y --no-install-recommends "${declare_debian_runtime[@]}" || echo "warn: some runtime deps failed"
+  _sudo apt-get install -y --no-install-recommends streamlink 2>/dev/null || true
+  command -v yt-dlp >/dev/null 2>&1 || pip3 install --user --break-system-packages yt-dlp 2>/dev/null || true
+  pip3 install --user --break-system-packages camoufox 2>/dev/null || true
+}
+
+install_fedora() {
+  echo "==> [fedora] build + runtime"
+  _sudo dnf install -y "${declare_fedora_build[@]}" "${declare_fedora_runtime[@]}" 2>/dev/null \
+    || _sudo dnf install -y "${declare_fedora_build[@]}" "${declare_fedora_runtime[@]}" || true
+  if ! rpm -q mpv ffmpeg >/dev/null 2>&1; then
+    _sudo dnf install -y "https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm" 2>/dev/null || true
+    _sudo dnf install -y mpv ffmpeg 2>/dev/null || true
+  fi
+}
+
+install_suse() {
+  echo "==> [suse] build + runtime"
+  _sudo zypper install -y "${declare_suse_build[@]}" "${declare_suse_runtime[@]}" 2>/dev/null || true
+}
+
+install_unknown() {
+  cat >&2 <<EOF
+warn: unknown distribution. Please install manually:
+  build:    zig>=0.15.2  gcc  git  pkg-config
+  runtime:  mpv  SDL2  sqlite3  libtorrent-rasterbar  curl  python3  python3-pip  ffmpeg  yt-dlp
+  optional: streamlink  onnxruntime  camoufox (pip install camoufox)
+EOF
+}
+
+case "$distro" in
+  arch)   install_arch ;;
+  debian) install_debian ;;
+  fedora) install_fedora ;;
+  suse)   install_suse ;;
+  alpine) _sudo apk add zig gcc git sdl2-dev mpv-dev sqlite-dev libtorrent-rasterbar curl python3 py3-pip ffmpeg yt-dlp 2>/dev/null || true ;;
+  void)   _sudo xbps-install -Sy zig gcc git SDL2-devel mpv-devel sqlite-devel libtorrent-rasterbar curl python3 python3-pip ffmpeg yt-dlp 2>/dev/null || true ;;
+  gentoo) _sudo emerge -av dev-lang/zig sys-devel/gcc dev-vcs/git media-libs/libsdl2 media-video/mpv dev-db/sqlite net-libs/libtorrent-rasterbar net-misc/curl dev-lang/python dev-python/pip media-video/ffmpeg media-video/yt-dlp 2>/dev/null || true ;;
+  nixos)  echo "NixOS detected — please use the project flake/devShell" ;;
+  *)      install_unknown ;;
+esac
+
+echo "==> deps install done. Re-run with --check to verify."

--- a/src/services/comics.zig
+++ b/src/services/comics.zig
@@ -1862,14 +1862,18 @@ fn decodePageTexture(pg: usize) void {
 // OCR + TTS Narration
 // ══════════════════════════════════════════════════════════
 
-// Native ONNX Runtime OCR via C wrapper
-const ocr_c = @cImport({
+// Native ONNX Runtime OCR via C wrapper. Gated by `-Docr=true`; empty
+// namespace otherwise so the @cImport never runs and onnxruntime isn't required.
+const ocr_build_options = @import("ocr_build_options");
+const has_ocr = ocr_build_options.has_ocr;
+const ocr_c = if (has_ocr) @cImport({
     @cInclude("ocr_ort.h");
-});
+}) else struct {};
 
 var ocr_initialized: bool = false;
 
 fn ensureOcrInit() bool {
+    if (!has_ocr) return false;
     if (ocr_initialized) return true;
 
     // Model paths: prefer PP-OCRv5 (much better accuracy), fall back to v4
@@ -1918,21 +1922,25 @@ pub fn ocrPage(pg: usize) void {
     }
     defer dvui.c.stbi_image_free(rgba);
 
-    // Run OCR via C wrapper
-    const result = ocr_c.ocr_recognize_rgba(
-        @ptrCast(rgba),
-        w,
-        h,
-    );
+    // Run OCR via C wrapper (gated so the empty-struct stub built when
+    // -Docr=false is never type-checked; Zig skips analysis of branches
+    // under a comptime-known condition).
+    if (has_ocr) {
+        const result = ocr_c.ocr_recognize_rgba(
+            @ptrCast(rgba),
+            w,
+            h,
+        );
 
-    if (result != null) {
-        const text: [*:0]const u8 = result.?;
-        const text_slice = std.mem.span(text);
-        const trimmed = std.mem.trim(u8, text_slice, " \t\r\n");
-        const len = @min(trimmed.len, 4095);
-        @memcpy(state.app.comic.ocr_texts[pg][0..len], trimmed[0..len]);
-        state.app.comic.ocr_lens[pg] = len;
-        ocr_c.ocr_free_text(result);
+        if (result != null) {
+            const text: [*:0]const u8 = result.?;
+            const text_slice = std.mem.span(text);
+            const trimmed = std.mem.trim(u8, text_slice, " \t\r\n");
+            const len = @min(trimmed.len, 4095);
+            @memcpy(state.app.comic.ocr_texts[pg][0..len], trimmed[0..len]);
+            state.app.comic.ocr_lens[pg] = len;
+            ocr_c.ocr_free_text(result);
+        }
     }
     state.app.comic.ocr_done[pg] = true;
 }

--- a/src/services/frame_ocr.zig
+++ b/src/services/frame_ocr.zig
@@ -20,9 +20,13 @@ const sync = @import("../core/sync.zig");
 const alloc = @import("../core/alloc.zig");
 
 // Native ONNX Runtime OCR via the same C wrapper comics.zig uses.
-const ocr_c = @cImport({
+// Gated by the `-Docr=true` build flag; empty namespace when OCR is off so
+// the @cImport never runs and onnxruntime isn't required.
+const ocr_build_options = @import("ocr_build_options");
+const has_ocr = ocr_build_options.has_ocr;
+const ocr_c = if (has_ocr) @cImport({
     @cInclude("ocr_ort.h");
-});
+}) else struct {};
 
 var ocr_initialized: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
 var ocr_init_failed: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
@@ -39,6 +43,7 @@ var scratch_mutex: sync.Mutex = .{};
 
 /// Lazily initialize the OCR pipeline exactly once. Returns true if usable.
 fn ensureOcrInit() bool {
+    if (!has_ocr) return false;
     if (ocr_initialized.load(.acquire)) return true;
     if (ocr_init_failed.load(.acquire)) return false;
 
@@ -120,6 +125,10 @@ pub fn ocrCurrentFrame(out_buf: []u8) usize {
     // Opaque video frame: PMA bytes == straight RGBA bytes. Pass the SNAPSHOT
     // (not the live p.pixels) so a concurrent render/realloc can't corrupt us.
     const rgba_ptr: [*]const u8 = buf.ptr;
+
+    // OCR call is gated by `has_ocr` so the empty-struct stub (`ocr_c={}`)
+    // built when -Docr=false is never type-checked.
+    if (!has_ocr) return 0;
 
     const result = ocr_c.ocr_recognize_rgba(rgba_ptr, w, h);
     if (result == null) return 0;


### PR DESCRIPTION
## Problem

A clean `git clone && zig build -Doptimize=ReleaseSafe` on Arch + Zig 0.16.0 fails:

1. **onnxruntime not found.** `build.zig` unconditionally links it; `frame_ocr.zig` / `comics.zig` `@cImport` `ocr_ort.h`. Arch only ships `onnxruntime-cpu/-cuda/-rocm` in `extra` — nothing pulls it in by default. OCR is a niche feature; forcing every user to install it just to build is wrong.
2. **Bundled SDL2 trips LLD.** Without `-fsys=sdl2`, dvui's static `libSDL2.a` has ELF shared-lib archive members; zig 0.16 escalates LLD's "neither ET_REL nor LLVM bitcode" warning into a build error.
3. **No way to repair runtime deps.** Installing the package on a system missing `mpv` / `SDL2` / `libtorrent-rasterbar` gives a silent failure.

## Fix

### Make OCR opt-in (`-Docr`, default false)

- `build.zig`: gate the `ort/ocr_ort.c` C source, `addIncludePath`, `linkSystemLibrary("onnxruntime")`, and `addRPath` inside `if (enable_ocr) { ... }`; surface `has_ocr` to source via `addOptions("ocr_build_options")`.
- `src/services/frame_ocr.zig`, `src/services/comics.zig`:

      const has_ocr = @import("ocr_build_options").has_ocr;
      const ocr_c = if (has_ocr) @cImport({ @cInclude("ocr_ort.h"); }) else struct {};

  Then gate every `ocr_c.*` call site behind `if (has_ocr) { ... }`. Zig lazily skips analysis of the false branch, so onnxruntime isn't needed to compile.

### Build with system SDL2

`PKGBUILD build()` now runs `zig build -fsys=sdl2 -Doptimize=ReleaseSafe`.

### Self-repairing runtime deps

- `scripts/install-deps.sh` — new installer: detects distro (arch/debian/fedora/suse/alpine/void/gentoo) and pulls the right packages. `--check` mode probes `ldconfig` + binaries and exits 0/1.
- `PKGBUILD package()` bundles it into `/opt/opal/install-deps.sh`.
- `/usr/bin/opal` launcher probes `ldconfig` + binaries at startup; if any are missing, prints `Opal: missing system libraries/binary detected. Repair with: sudo /opt/opal/install-deps.sh`.

## Verified end-to-end on Arch x86_64 (zig 0.16.0)

| Step | Result |
|---|---|
| `zig build -fsys=sdl2 -Doptimize=ReleaseSafe` | builds `zig-out/bin/opal` (29M, no onnxruntime needed) |
| `./zig-out/bin/opal` | JSON API on :41595, video plays, clean shutdown |
| `makepkg -f --nodeps --noconfirm --noextract` | `opal-0.1.1-1-x86_64.pkg.tar.zst` (2.9M) |
| `tar -tf` package contents | `opt/opal/{opal, libtorrent_wrapper.so, install-deps.sh, camoufox_bridge.py, ort/...}`, `usr/bin/opal`, desktop entry, `opal.svg` icon, `LICENSE` |
| `./scripts/install-deps.sh --check` | exit 0 (all deps present) |

## Notes

- OCR is **off** by default. Users who want it: `pacman -S onnxruntime-cpu && zig build -Docr=true -fsys=sdl2 -Doptimize=ReleaseSafe`.
- Makepkg from the project root needs `--noextract` because the project's source dir is named `src/` (same as makepkg's `$srcdir`). This is documented in the PKGBUILD header; an AUR-side publish would swap `source=()` for the git tag tarball, sidestepping that.
- The AUR `opal` package name is unrelated (`opal-voip`); this project's binary is `opal` so the eventual AUR package should publish under `opal-bin` / `opal-git` to reserve the `opal` slot for an official release.

## Test plan

- [ ] Clean build on Arch with this PR applied — passes `zig build -fsys=sdl2 -Doptimize=ReleaseSafe` with no onnxruntime installed
- [ ] `makepkg -f --noextract --nodeps --noconfirm` produces `opal-0.1.1-1-x86_64.pkg.tar.zst`
- [ ] `sudo pacman -U opal-*.pkg.tar.zst && opal` launches
- [ ] OCR path still works when built with `-Docr=true` (on dev machine, not in this PR's CI)
- [ ] No regression on macOS Homebrew formula (untouched)