### PR TITLE
fix(plex): restored session loads its library; harden stale-append guards

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -387,6 +387,16 @@ pub fn build(b: *std.Build) void {
     });
     test_step.dependOn(&b.addRunArtifact(test_subs_pure).step);
 
+    // Plex: restored-session section load trigger + stale-worker publish guard.
+    const test_plex_pure = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/services/plex_pure.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    test_step.dependOn(&b.addRunArtifact(test_plex_pure).step);
+
     // Anime NSFW filter: Jikan rating classification + sfw query param.
     const test_anime_pure = b.addTest(.{
         .root_module = b.createModule(.{

--- a/src/services/plex.zig
+++ b/src/services/plex.zig
@@ -11,6 +11,7 @@ const alloc = @import("../core/alloc.zig").allocator;
 const paths = @import("../core/paths.zig");
 const logs = @import("../core/logs.zig");
 const state = @import("../core/state.zig");
+const plex_pure = @import("plex_pure.zig");
 
 const CLIENT_ID = "opal-media-9a3f"; // X-Plex-Client-Identifier (stable per build)
 const Json = std.json.Value;
@@ -69,6 +70,20 @@ var current_start: usize = 0;
 var more_available: bool = true;
 var loading_more: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
 
+// A section index alone can't tell "still the same fetch" from "the same section
+// was re-opened mid-fetch" (see plex_pure.workerMayPublish). `view_gen` is bumped
+// on every section switch/reload; workers capture it before spawning and re-check
+// it after the round-trip, so an A→B→A switch can't land a stale page.
+var view_gen: std.atomic.Value(u64) = std.atomic.Value(u64).init(1);
+// Section-load state for the restored-session trigger in renderContent().
+// `sections_loaded_once` latches only once a fetch actually PARSES — an empty
+// library is a successful load, so this can't be `section_count > 0` (that would
+// poll a zero-library server forever), and it must not be set before the fetch
+// or one transient failure would blank the tab for the whole run.
+var sections_loading: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
+var sections_loaded_once: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
+var sections_last_attempt_s: std.atomic.Value(i64) = std.atomic.Value(i64).init(0);
+
 fn setStatus(comptime fmt: []const u8, args: anytype) void {
     const s = std.fmt.bufPrint(&status_msg, fmt, args) catch status_msg[0..0];
     status_msg_len = s.len;
@@ -121,6 +136,11 @@ pub fn disconnect() void {
     item_count = 0;
     current_start = 0;
     more_available = true;
+    // Clear the load latch too — otherwise signing into a DIFFERENT account
+    // would skip the section fetch and land on a permanently blank library.
+    sections_loaded_once.store(false, .release);
+    sections_last_attempt_s.store(0, .release);
+    _ = view_gen.fetchAdd(1, .acq_rel); // supersede any in-flight worker
     conn_state.store(.disconnected, .release);
     save();
 }
@@ -275,6 +295,11 @@ fn discoverServers() void {
         setStatus("Connected: {s}", .{server_name[0..server_name_len]});
         save();
         state.showToastTyped("Connected to Plex", .success);
+        // Claim the in-flight flag so the renderContent() trigger can't stack a
+        // second worker on top of this inline load (and so its defer clears a
+        // flag we actually own).
+        _ = sections_loading.swap(true, .acq_rel);
+        sections_last_attempt_s.store(io.timestamp(), .release);
         fetchSectionsSync();
         return;
     }
@@ -285,19 +310,37 @@ fn discoverServers() void {
 // ── libraries + items ────────────────────────────────────────────────────────
 pub fn fetchSections() void {
     if (!isConnected()) return;
-    (std.Thread.spawn(.{}, fetchSectionsSync, .{}) catch return).detach();
+    if (sections_loading.swap(true, .acq_rel)) return; // a worker is already in flight
+    sections_last_attempt_s.store(io.timestamp(), .release);
+    (std.Thread.spawn(.{}, fetchSectionsSync, .{}) catch {
+        sections_loading.store(false, .release);
+        return;
+    }).detach();
 }
 fn fetchSectionsSync() void {
+    defer sections_loading.store(false, .release);
     var url: [320]u8 = undefined;
     const u = std.fmt.bufPrint(&url, "{s}/library/sections", .{server_uri[0..server_uri_len]}) catch return;
     var buf: [65536]u8 = undefined;
     const n = httpGet(u, false, serverTok(), &buf);
-    if (n == 0) return;
+    if (n == 0) {
+        logs.pushLog("warn", "plex", "Library list failed — retrying shortly", true);
+        return;
+    }
     var parsed = std.json.parseFromSlice(Json, alloc, buf[0..n], .{}) catch return;
     defer parsed.deinit();
+    if (parsed.value != .object) return;
     const mc = parsed.value.object.get("MediaContainer") orelse return;
-    const dirs = mc.object.get("Directory") orelse return;
+    if (mc != .object) return;
+    const dirs = mc.object.get("Directory") orelse {
+        // A server with no libraries answers without a Directory array. That's a
+        // successful (empty) load, not a failure — latch so we stop re-fetching.
+        sections_loaded_once.store(true, .release);
+        return;
+    };
     if (dirs != .array) return;
+    // Past parsing — whatever the count, this fetch succeeded.
+    sections_loaded_once.store(true, .release);
     section_count = 0;
     for (dirs.array.items) |d| {
         if (section_count >= sections.len or d != .object) continue;
@@ -315,33 +358,60 @@ fn fetchSectionsSync() void {
     }
     if (section_count > 0) {
         active_section = 0;
-        fetchItemsSync(0);
+        fetchItemsSync(0, view_gen.fetchAdd(1, .acq_rel) + 1);
     }
+}
+
+/// Reset the grid + pagination for a fresh section load, and claim `is_loading`.
+/// Callers MUST do this before the fetch worker spawns, never inside it — see
+/// fetchItems().
+fn beginSectionLoad() void {
+    is_loading.store(true, .release);
+    item_count = 0;
+    current_start = 0;
+    more_available = true;
 }
 
 pub fn fetchItems(section_idx: usize) void {
     if (!isConnected() or section_idx >= section_count) return;
     active_section = section_idx;
+    // Supersede every in-flight worker: re-opening the SAME section still yields
+    // a new generation, which is what an index compare alone can't express.
+    const new_gen = view_gen.fetchAdd(1, .acq_rel) + 1;
+    // Reset on THIS (UI) thread, before the spawn. Doing it inside the worker
+    // leaves a window where renderContent's infinite-scroll block — which runs
+    // later in this SAME frame, since the tab click doesn't return — sees the
+    // NEW active_section beside the OLD section's current_start, with is_loading
+    // still false because the worker hasn't been scheduled yet. loadMore() then
+    // appends the new section at the old section's offset (e.g. TV Shows rows
+    // 0-49 followed by 100-149, 50 titles silently missing, current_start
+    // stranded at 150). The generation guard can't catch that: loadMore reads
+    // view_gen after this bump, so its stale append carries the CURRENT gen.
+    beginSectionLoad();
     const S = struct {
         var idx: usize = 0;
+        var gen: u64 = 0;
         fn run() void {
-            fetchItemsSync(idx);
+            defer is_loading.store(false, .release);
+            fetchWindow(@This().idx, 0, @This().gen);
         }
     };
     S.idx = section_idx;
-    (std.Thread.spawn(.{}, S.run, .{}) catch return).detach();
+    S.gen = new_gen;
+    if (std.Thread.spawn(.{}, S.run, .{})) |t| {
+        t.detach();
+    } else |_| {
+        is_loading.store(false, .release); // never strand the tab "loading"
+    }
 }
-fn fetchItemsSync(section_idx: usize) void {
+/// Initial load driven by the section-list worker. Unlike fetchItems() this
+/// already runs off the UI thread, and item_count == 0 makes loadMore() bail, so
+/// there's no same-frame append to race with.
+fn fetchItemsSync(section_idx: usize, gen: u64) void {
     if (section_idx >= section_count) return;
-    is_loading.store(true, .release);
+    beginSectionLoad();
     defer is_loading.store(false, .release);
-    // Fresh section open — reset the grid + pagination before pulling window 0.
-    // (active_section is set by the caller, fetchItems(), before this thread
-    // spawns, so fetchWindow's post-fetch section check passes.)
-    item_count = 0;
-    current_start = 0;
-    more_available = true;
-    fetchWindow(section_idx, 0);
+    fetchWindow(section_idx, 0, gen);
 }
 
 /// Fetch one X-Plex-Container-Start/Size window for `section_idx` and append
@@ -351,7 +421,7 @@ fn fetchItemsSync(section_idx: usize) void {
 /// Advances `current_start` by the server-reported row count (not just the
 /// rows we managed to store) and clears `more_available` once a window comes
 /// back short or the fixed items[] buffer fills.
-fn fetchWindow(section_idx: usize, start: usize) void {
+fn fetchWindow(section_idx: usize, start: usize, gen: u64) void {
     if (section_idx >= section_count) return;
     const sec = &sections[section_idx];
     var url: [460]u8 = undefined;
@@ -364,12 +434,13 @@ fn fetchWindow(section_idx: usize, start: usize) void {
     var parsed = std.json.parseFromSlice(Json, alloc, buf[0..n], .{}) catch return;
     defer parsed.deinit();
 
-    // The user may have switched library sections while this window was in
-    // flight — bail before touching ANY shared pagination state (item_count,
-    // current_start, more_available all belong to whichever section is
-    // currently open; a stale response — even an error/empty one — must not
-    // clobber the newly-selected section's state).
-    if (section_idx != active_section) return;
+    // The user may have switched sections — or re-opened THIS one, which resets
+    // item_count/current_start — while this window was in flight. Bail before
+    // touching ANY shared pagination state (item_count, current_start,
+    // more_available all belong to whichever load is currently live; a stale
+    // response — even an error/empty one — must not clobber it). The generation
+    // is what catches the A→B→A case the index compare passes.
+    if (!plex_pure.workerMayPublish(section_idx, gen, active_section, view_gen.load(.acquire))) return;
 
     const mc = parsed.value.object.get("MediaContainer") orelse return;
     const meta = mc.object.get("Metadata") orelse {
@@ -434,13 +505,16 @@ pub fn loadMore() void {
     const S = struct {
         var section_idx: usize = 0;
         var start: usize = 0;
+        var gen: u64 = 0;
         fn run() void {
             defer loading_more.store(false, .release);
-            fetchWindow(@This().section_idx, @This().start);
+            fetchWindow(@This().section_idx, @This().start, @This().gen);
         }
     };
     S.section_idx = active_section;
     S.start = current_start;
+    // Capture (not bump) — an append belongs to the load that's already live.
+    S.gen = view_gen.load(.acquire);
     if (std.Thread.spawn(.{}, S.run, .{})) |t| {
         t.detach();
     } else |_| {
@@ -484,6 +558,18 @@ pub fn renderContent() void {
         }
         return;
     }
+
+    // A restored token (init() → conn_state = .connected) skips the sign-in panel
+    // above, but nothing else ever loaded the library: fetchSections() had zero
+    // callers, so every relaunch drew this header over an empty tab. Kick the
+    // load here, backed off so a failure retries instead of latching blank.
+    if (plex_pure.shouldFetchSections(
+        isConnected(),
+        sections_loaded_once.load(.acquire),
+        sections_loading.load(.acquire),
+        sections_last_attempt_s.load(.acquire),
+        io.timestamp(),
+    )) fetchSections();
 
     // Header: server + section tabs + disconnect.
     {

--- a/src/services/plex_pure.zig
+++ b/src/services/plex_pure.zig
@@ -1,0 +1,151 @@
+//! Pure decision logic for the Plex tab — no I/O, no dvui, no globals, so it can
+//! be unit-tested. `plex.zig` routes through these so the tested logic is the
+//! shipped logic.
+
+const std = @import("std");
+
+/// How long to wait before re-attempting a section load that failed. Short
+/// enough that a user who fixes their wifi sees the library without a restart,
+/// long enough that a persistent failure doesn't spawn a curl per frame.
+pub const SECTIONS_RETRY_S: i64 = 15;
+
+/// Should the Plex tab kick off a `/library/sections` fetch this frame?
+///
+/// The bug this exists for: `init()` restores a persisted token and stamps
+/// `conn_state = .connected`, but only `connect()` (the first-run PIN flow) ever
+/// called `fetchSectionsSync()`. So on every relaunch `renderContent()` saw
+/// `isConnected() == true`, skipped the sign-in panel, drew the "Plex · <server>"
+/// header — and then drew zero section tabs and zero rows, forever. A restored
+/// session had a permanently blank library.
+///
+/// `loaded_once` latches on a SUCCESSFUL fetch — not before it, and not on
+/// "section_count > 0". Both alternatives are wrong:
+///   - Latching before success turns one transient failure (wifi still coming up
+///     at launch, server asleep) into a blank tab for the whole run — the same
+///     class of bug this fixes. So the caller latches only after a fetch parses.
+///   - Latching on "we have sections" looks equivalent but silently breaks a
+///     server with ZERO libraries: the fetch succeeds, returns an empty list,
+///     and a count-based check would keep firing a /library/sections curl every
+///     SECTIONS_RETRY_S seconds forever. An empty library is a successful load.
+/// Until that latch, `last_attempt_s` + the backoff give a failed load a retry
+/// without spawning a worker per frame.
+pub fn shouldFetchSections(
+    connected: bool,
+    loaded_once: bool,
+    loading: bool,
+    last_attempt_s: i64,
+    now_s: i64,
+) bool {
+    if (!connected) return false;
+    if (loaded_once) return false; // a fetch already succeeded (even if empty)
+    if (loading) return false; // a worker is in flight; don't stack another
+    if (last_attempt_s == 0) return true; // never tried
+    return now_s - last_attempt_s >= SECTIONS_RETRY_S;
+}
+
+/// May a completed worker publish its results into shared state?
+///
+/// The identity check `section_idx == active_section` is necessary but NOT
+/// sufficient: a section index cannot distinguish "still the same fetch" from
+/// "the same section was re-opened while this fetch was in flight". The A→B→A
+/// interleaving that defeats it:
+///
+///   1. In section 0 at the bottom, `loadMore()` spawns W1 = fetchWindow(0, 50);
+///      it blocks in httpGet.
+///   2. User clicks section 1 → active_section = 1.
+///   3. User clicks section 0 again → active_section = 0, and the fresh load
+///      resets item_count = 0, current_start = 0.
+///   4. W1 returns. `0 == 0` passes, so it appends a stale window-50 page into
+///      the freshly-reset list → duplicated/misordered rows and a corrupted
+///      current_start, so a page of items is silently skipped or repeated.
+///
+/// A monotonic generation bumped on every switch/reload closes it: the worker
+/// captures the generation before spawning and re-checks it here, so a fetch
+/// issued under a superseded view is dropped even when the index matches again.
+pub fn workerMayPublish(
+    captured_section: usize,
+    captured_gen: u64,
+    current_section: usize,
+    current_gen: u64,
+) bool {
+    return captured_section == current_section and captured_gen == current_gen;
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+test "regression: restored token with no sections triggers a fetch (blank-tab-on-restart)" {
+    // The exact relaunch state: init() restored the token (connected) but nothing
+    // ever called fetchSections, so section_count == 0 and no attempt was made.
+    try std.testing.expect(shouldFetchSections(true, false, false, 0, 1000));
+}
+
+test "shouldFetchSections: no fetch when disconnected" {
+    try std.testing.expect(!shouldFetchSections(false, false, false, 0, 1000));
+}
+
+test "shouldFetchSections: a successful load stops the trigger" {
+    try std.testing.expect(!shouldFetchSections(true, true, false, 0, 1000));
+}
+
+test "regression: a server with ZERO libraries must not poll forever" {
+    // A successful fetch that returns an empty section list IS a load. Latching
+    // on "section_count > 0" instead of "the fetch succeeded" would leave this
+    // firing a /library/sections curl every SECTIONS_RETRY_S for the whole run.
+    const loaded_once = true; // fetch succeeded; it just had nothing in it
+    try std.testing.expect(!shouldFetchSections(true, loaded_once, false, 1000, 1000 + 10_000));
+}
+
+test "shouldFetchSections: no stacking while a worker is in flight" {
+    try std.testing.expect(!shouldFetchSections(true, false, true, 0, 1000));
+}
+
+test "shouldFetchSections: a failed attempt retries only after the backoff" {
+    // Attempt stamped at t=1000. Must not re-fire every frame...
+    try std.testing.expect(!shouldFetchSections(true, false, false, 1000, 1000));
+    try std.testing.expect(!shouldFetchSections(true, false, false, 1000, 1000 + SECTIONS_RETRY_S - 1));
+    // ...but must recover on its own once the backoff elapses (no restart needed).
+    try std.testing.expect(shouldFetchSections(true, false, false, 1000, 1000 + SECTIONS_RETRY_S));
+    try std.testing.expect(shouldFetchSections(true, false, false, 1000, 1000 + 600));
+}
+
+test "shouldFetchSections: a backwards clock can't wedge the retry permanently" {
+    // now < last_attempt (NTP step / suspend). Must not fire a burst, and must
+    // not latch forever either — the next in-window tick behaves normally.
+    try std.testing.expect(!shouldFetchSections(true, false, false, 5000, 1000));
+}
+
+test "regression: A→B→A section switch is rejected by the generation guard" {
+    // 1. Section 0 open at the bottom; loadMore() spawns W1 = window(start=50)
+    //    under gen 7. It blocks in httpGet.
+    const w1_section: usize = 0;
+    const w1_gen: u64 = 7;
+    // 2. User clicks section 1 → active_section = 1, gen bumps to 8.
+    try std.testing.expect(!workerMayPublish(w1_section, w1_gen, 1, 8));
+    // 3. User clicks section 0 again → active_section = 0, gen bumps to 9, and
+    //    the reload resets item_count / current_start.
+    const active: usize = 0;
+    const gen_now: u64 = 9;
+    // 4. W1 returns. Its SECTION still matches — the old section-only guard
+    //    passed here and appended a stale window onto the freshly reset list.
+    try std.testing.expect(w1_section == active); // the old guard passed…
+    try std.testing.expect(!workerMayPublish(w1_section, w1_gen, active, gen_now)); // …the generation drops it
+}
+
+test "regression: the reload's own worker still publishes after A→B→A" {
+    // The guard must not be so strict it drops the LIVE worker: W3 is the
+    // section-0 reload itself (gen 9) and must be allowed to publish.
+    try std.testing.expect(workerMayPublish(0, 9, 0, 9));
+}
+
+test "workerMayPublish: the in-flight fetch for the live view publishes" {
+    try std.testing.expect(workerMayPublish(0, 7, 0, 7));
+}
+
+test "workerMayPublish: a plain mid-fetch switch to another section is rejected" {
+    try std.testing.expect(!workerMayPublish(0, 7, 1, 8));
+}
+
+test "workerMayPublish: same generation but a different section is rejected" {
+    // Defensive: generation alone isn't the whole identity either.
+    try std.testing.expect(!workerMayPublish(0, 7, 1, 7));
+}

--- a/tests/features/test_plex_restore.py
+++ b/tests/features/test_plex_restore.py
@@ -1,0 +1,103 @@
+"""Plex — a restored session must actually load its library.
+
+Regression for the blank-tab-on-restart bug: init() restored the persisted token
+and stamped conn_state = .connected, so renderContent() skipped the sign-in panel
+and drew the "Plex · <server>" header — but the ONLY caller of the section fetch
+was connect(), the first-run PIN flow. fetchSections() itself had ZERO callers, so
+section_count stayed 0 and every relaunch showed a connected-looking, permanently
+empty library.
+
+A pure unit test can't catch "this function is never called" — that's a wiring
+property of the whole tree, so it's asserted here.
+
+See tests/features/harness.py for the shared @test decorator + helpers."""
+from .harness import *  # noqa: F401,F403
+
+import re
+
+
+def _callers(src, fn):
+    """Count call sites of `fn` outside its own declaration.
+
+    Matches `fn(` but not `fn fn(` (the decl) and not `.fn(` (a method on
+    something else). A detached-thread spawn passes the bare name with no
+    parens — `Thread.spawn(.{}, fn, .{})` — so that form counts too.
+    """
+    calls = len([
+        m for m in re.finditer(r"(?<![.\w])" + re.escape(fn) + r"\s*\(", src)
+        if not src[:m.start()].rstrip().endswith("fn")
+    ])
+    spawns = len(re.findall(r"spawn\([^)]*?,\s*" + re.escape(fn) + r"\s*,", src))
+    return calls + spawns
+
+
+@test("Plex restored session loads its library", "Plex")
+def test_plex_restored_session_loads_library():
+    svc = _src("src/services/plex.zig")
+    pure = _src("src/services/plex_pure.zig")
+
+    checks = {}
+
+    # The bug itself: the section fetch must be reachable from the render path,
+    # not only from the first-run PIN flow.
+    checks["fetchSections has a caller"] = _callers(svc, "fetchSections") > 0
+    checks["renderContent triggers the section load"] = (
+        "shouldFetchSections" in svc and "fetchSections()" in svc
+    )
+
+    # It must NOT be a latch set before the fetch succeeds — that turns one
+    # transient failure at launch into a blank tab for the whole run.
+    checks["retry is backed off, not latched"] = "SECTIONS_RETRY_S" in pure
+    checks["attempt timestamp is stamped"] = "sections_last_attempt_s" in svc
+    checks["in-flight guard prevents a fetch per frame"] = "sections_loading" in svc
+
+    # ...and it must latch on the fetch SUCCEEDING, not on "we got sections".
+    # A server with zero libraries loads successfully and empty; a count-based
+    # latch would re-curl /library/sections every retry window forever.
+    checks["latches on success, not on section_count"] = "sections_loaded_once" in svc
+    checks["empty library still counts as loaded"] = (
+        "sections_loaded_once.store(true" in svc
+    )
+    # Signing out must clear it, or a different account lands on a blank library.
+    checks["disconnect clears the load latch"] = (
+        "sections_loaded_once.store(false" in svc
+    )
+    checks["a failed load is surfaced to the user"] = (
+        'pushLog("warn", "plex"' in svc or "pushLog(\"warn\", \"plex\"" in svc
+    )
+
+    # Production must route through the tested predicate (no drift).
+    checks["render path uses the pure predicate"] = "plex_pure.shouldFetchSections(" in svc
+
+    # Stale-append guard: a section index alone can't distinguish "same fetch"
+    # from "same section re-opened" (the A -> B -> A case).
+    checks["generation counter exists"] = "view_gen" in svc
+    checks["worker publish routes through the pure guard"] = "plex_pure.workerMayPublish(" in svc
+    checks["generation is bumped on section switch"] = "view_gen.fetchAdd" in svc
+    checks["bare index compare no longer gates the append"] = (
+        "if (section_idx != active_section) return;" not in svc
+    )
+
+    # The generation guard alone does NOT cover the same-frame case: loadMore()
+    # reads view_gen after fetchItems() bumped it, so a stale append inherits the
+    # current generation and passes. fetchItems must therefore claim is_loading
+    # and reset the cursor on the UI thread BEFORE spawning, or the same frame's
+    # infinite-scroll block appends the new section at the old section's offset.
+    fetch_items = svc.split("pub fn fetchItems(")[1].split("\npub fn ")[0] if "pub fn fetchItems(" in svc else ""
+    checks["fetchItems resets before spawning (not in the worker)"] = (
+        "beginSectionLoad()" in fetch_items
+        and fetch_items.index("beginSectionLoad()") < fetch_items.index("Thread.spawn")
+    )
+    checks["reset claims is_loading synchronously"] = "is_loading.store(true" in svc.split("fn beginSectionLoad()")[1][:200]
+    checks["a failed spawn doesn't strand the tab loading"] = (
+        "is_loading.store(false, .release); // never strand" in svc
+    )
+
+    missing = [k for k, ok in checks.items() if not ok]
+    if missing:
+        return "fail", "plex restored-session load incomplete: " + ", ".join(missing)
+    return "pass", (
+        "restored token loads the library: fetchSections reachable from the render "
+        "path, backed-off retry (not a pre-success latch), failure surfaced; "
+        "stale-append guarded by a generation counter (A->B->A safe)"
+    )

--- a/tests/results.json
+++ b/tests/results.json
@@ -1,9 +1,9 @@
 {
-  "timestamp": "2026-07-17T03:33:12",
-  "total": 216,
-  "passed": 205,
+  "timestamp": "2026-07-17T05:17:16",
+  "total": 217,
+  "passed": 207,
   "failed": 0,
-  "warnings": 3,
+  "warnings": 2,
   "skipped": 8,
   "categories": {
     "Database": {
@@ -31,9 +31,9 @@
       "skip": 0
     },
     "Build": {
-      "pass": 5,
+      "pass": 6,
       "fail": 0,
-      "warn": 1,
+      "warn": 0,
       "skip": 0
     },
     "LLM": {
@@ -227,6 +227,12 @@
       "fail": 0,
       "warn": 0,
       "skip": 0
+    },
+    "Plex": {
+      "pass": 1,
+      "fail": 0,
+      "warn": 0,
+      "skip": 0
     }
   },
   "tests": [
@@ -234,21 +240,21 @@
       "name": "Database Exists",
       "category": "Database",
       "status": "pass",
-      "detail": "Size: 30752.0 KB",
+      "detail": "Size: 45092.0 KB",
       "duration_ms": 0
     },
     {
       "name": "Config Table",
       "category": "Database",
       "status": "pass",
-      "detail": "76 config entries",
-      "duration_ms": 3
+      "detail": "75 config entries",
+      "duration_ms": 2
     },
     {
       "name": "Watch History Table",
       "category": "Database",
       "status": "pass",
-      "detail": "1 watch entries",
+      "detail": "5 watch entries",
       "duration_ms": 0
     },
     {
@@ -262,7 +268,7 @@
       "name": "Download History Table",
       "category": "Database",
       "status": "pass",
-      "detail": "1 downloads",
+      "detail": "3 downloads",
       "duration_ms": 0
     },
     {
@@ -290,8 +296,8 @@
       "name": "Poster Cache Table",
       "category": "Database",
       "status": "pass",
-      "detail": "477 cached posters",
-      "duration_ms": 1
+      "detail": "744 cached posters",
+      "duration_ms": 0
     },
     {
       "name": "Conversation Log Table",
@@ -304,7 +310,7 @@
       "name": "User Preferences Table",
       "category": "Memory",
       "status": "pass",
-      "detail": "active_hour=22:00 (w:108)",
+      "detail": "active_hour=22:00 (w:113)",
       "duration_ms": 0
     },
     {
@@ -353,7 +359,7 @@
       "name": "Window State Persistence",
       "category": "Config",
       "status": "pass",
-      "detail": "1280x771 at (0,61)",
+      "detail": "1244x771 at (0,61)",
       "duration_ms": 0
     },
     {
@@ -375,14 +381,14 @@
       "category": "Memory",
       "status": "pass",
       "detail": "sidebar SELECT + restore + tagged INSERT OK against schema",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "name": "Total Recall Wired",
       "category": "Recall",
       "status": "pass",
       "detail": "scene capture + recall_scene tool + DB store wired",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "name": "aimemory position_secs Column",
@@ -410,20 +416,20 @@
       "category": "Build",
       "status": "pass",
       "detail": "Binary: 46.3 MB",
-      "duration_ms": 490
+      "duration_ms": 483
     },
     {
       "name": "Binary Exists",
       "category": "Build",
       "status": "pass",
-      "detail": "46.3 MB, built at 03:32:58",
+      "detail": "46.3 MB, built at 05:17:01",
       "duration_ms": 0
     },
     {
       "name": "LLM Model File",
       "category": "Build",
-      "status": "warn",
-      "detail": "No GGUF model found",
+      "status": "pass",
+      "detail": "gemma-4-E2B-it-UD-Q4_K_XL.gguf (3.0 GB)",
       "duration_ms": 0
     },
     {
@@ -445,14 +451,14 @@
       "category": "Build",
       "status": "pass",
       "detail": "author credited across about/copyright/packaging surfaces",
-      "duration_ms": 1
+      "duration_ms": 2
     },
     {
       "name": "LLM Server Health",
       "category": "LLM",
       "status": "skip",
       "detail": "LLM server not running",
-      "duration_ms": 32
+      "duration_ms": 31
     },
     {
       "name": "Embedding Server Health",
@@ -466,7 +472,7 @@
       "category": "Server",
       "status": "pass",
       "detail": "compile-time headless entry + coreInit/headlessMain + 0.0.0.0 bind + -Dheadless",
-      "duration_ms": 1
+      "duration_ms": 2
     },
     {
       "name": "Headless Render Guards",
@@ -480,7 +486,7 @@
       "category": "Unit Tests",
       "status": "pass",
       "detail": "all pure-Zig unit tests pass",
-      "duration_ms": 2552
+      "duration_ms": 2308
     },
     {
       "name": "Poster/image fetch uses curl not std.http",
@@ -515,7 +521,7 @@
       "category": "Network",
       "status": "pass",
       "detail": "curl content fetchers bound connect time (dead host fails in ~3s)",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "HTTP client seeds Client.now for TLS",
@@ -536,7 +542,7 @@
       "category": "Packaging",
       "status": "pass",
       "detail": "install.sh installs the vendored .app; formula is a binary install at 0.4.0",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "name": "File associations + single instance",
@@ -557,35 +563,35 @@
       "category": "Voice",
       "status": "skip",
       "detail": "silero-vad not installed (optional)",
-      "duration_ms": 1095
+      "duration_ms": 1087
     },
     {
       "name": "Faster-Whisper Available",
       "category": "Voice",
       "status": "pass",
       "detail": "faster-whisper importable",
-      "duration_ms": 1223
+      "duration_ms": 1119
     },
     {
       "name": "KittenTTS Available",
       "category": "Voice",
       "status": "skip",
       "detail": "kittentts not installed (optional)",
-      "duration_ms": 25
+      "duration_ms": 22
     },
     {
       "name": "PulseAudio Echo Cancel",
       "category": "Voice",
       "status": "skip",
       "detail": "pactl not available",
-      "duration_ms": 23
+      "duration_ms": 21
     },
     {
       "name": "Conversational: voice-server echo guard + live partials",
       "category": "Voice",
       "status": "pass",
       "detail": "echo guard drops self-echo; real interruption passes; PARTIAL streamed",
-      "duration_ms": 32
+      "duration_ms": 30
     },
     {
       "name": "Conversational: prefer full-duplex event loop + wiring",
@@ -599,56 +605,56 @@
       "category": "Voice Scripts",
       "status": "pass",
       "detail": "py_compile OK",
-      "duration_ms": 29
+      "duration_ms": 26
     },
     {
       "name": "Compiles: opal-stt-server.py",
       "category": "Voice Scripts",
       "status": "pass",
       "detail": "py_compile OK",
-      "duration_ms": 27
+      "duration_ms": 25
     },
     {
       "name": "Compiles: opal-tts-server.py",
       "category": "Voice Scripts",
       "status": "pass",
       "detail": "py_compile OK",
-      "duration_ms": 28
+      "duration_ms": 24
     },
     {
       "name": "Compiles: opal-voice-server.py",
       "category": "Voice Scripts",
       "status": "pass",
       "detail": "py_compile OK",
-      "duration_ms": 29
+      "duration_ms": 27
     },
     {
       "name": "--check degrades: opal-stt-server.py",
       "category": "Voice Scripts",
       "status": "pass",
       "detail": "clean exit 0 (deps present)",
-      "duration_ms": 1044
+      "duration_ms": 995
     },
     {
       "name": "--check degrades: opal-tts-server.py",
       "category": "Voice Scripts",
       "status": "pass",
       "detail": "clean exit 4 (deps absent (fallback))",
-      "duration_ms": 27
+      "duration_ms": 26
     },
     {
       "name": "--check degrades: opal-voice-server.py",
       "category": "Voice Scripts",
       "status": "pass",
       "detail": "clean exit 0 (deps present)",
-      "duration_ms": 1104
+      "duration_ms": 1060
     },
     {
       "name": "Tracked + compiles: tools/lang_server.py",
       "category": "Voice Scripts",
       "status": "pass",
       "detail": "tracked + py_compile OK",
-      "duration_ms": 47
+      "duration_ms": 46
     },
     {
       "name": "Parakeet conversational self-install wired",
@@ -851,7 +857,7 @@
       "category": "AI Models",
       "status": "pass",
       "detail": "all 5 URLs resolve (HTTP 200)",
-      "duration_ms": 2950
+      "duration_ms": 4185
     },
     {
       "name": "Cloud LLM Backend + No Silent Local Installs",
@@ -879,14 +885,14 @@
       "category": "AI Features",
       "status": "pass",
       "detail": "console transcript + hero + follow-scroll + agent steps wired",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "name": "OMDb Ratings Enrichment",
       "category": "Enrichment",
       "status": "pass",
       "detail": "OMDb enrichment wired (parser+worker+UI+persist); key set=False",
-      "duration_ms": 3
+      "duration_ms": 2
     },
     {
       "name": "Local taste engine: activity + vectors + For You",
@@ -963,14 +969,14 @@
       "category": "UI Standards",
       "status": "pass",
       "detail": "no emoji in UI string literals",
-      "duration_ms": 86
+      "duration_ms": 90
     },
     {
       "name": "Browser: CloakBrowser engine + upgrades",
       "category": "Browser",
       "status": "pass",
       "detail": "engine picker + find/zoom/downloads/history/reader wired",
-      "duration_ms": 64
+      "duration_ms": 60
     },
     {
       "name": "Single-Media Mode",
@@ -1026,14 +1032,14 @@
       "category": "Browse",
       "status": "pass",
       "detail": "deferred watch commit + confident auto-play + first-run wizard wired",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "name": "Onboarding: paged feature tour + replay from Settings",
       "category": "Browse",
       "status": "pass",
       "detail": "paged tour + pure nav + replay from Settings \u203a About",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "name": "TV Calendar: Coming-Up Rail + EZTV Availability + HW Decode",
@@ -1166,21 +1172,21 @@
       "category": "Security",
       "status": "pass",
       "detail": "user-triggered VT deep links: magnet btih + file sha256/md5",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "name": "Anime-Skip auto-skip",
       "category": "Player",
       "status": "pass",
       "detail": "anime-skip: findEpisodeByName \u2192 point\u2192range \u2192 gated auto-seek",
-      "duration_ms": 7
+      "duration_ms": 0
     },
     {
       "name": "Torrent file loading",
       "category": "Player",
       "status": "pass",
       "detail": "torrent_add_file C API + .torrent route + shared player attach",
-      "duration_ms": 4
+      "duration_ms": 0
     },
     {
       "name": "Log Severity By Level",
@@ -1201,7 +1207,7 @@
       "category": "Stability",
       "status": "pass",
       "detail": "all 58 default-valued fields assigned in init",
-      "duration_ms": 6
+      "duration_ms": 2
     },
     {
       "name": "Stream Resources Resolvable When Bundled",
@@ -1250,7 +1256,7 @@
       "category": "Stability",
       "status": "pass",
       "detail": "no discarded std.Thread.spawn handles in src/",
-      "duration_ms": 20
+      "duration_ms": 19
     },
     {
       "name": "TMDB Fetch Stages Results Off-Thread",
@@ -1425,7 +1431,7 @@
       "category": "Page Shell",
       "status": "pass",
       "detail": "11 engines placed, class==module, manifest-wired",
-      "duration_ms": 2
+      "duration_ms": 3
     },
     {
       "name": "Polish Tokens Adopted",
@@ -1460,7 +1466,7 @@
       "category": "Page Shell",
       "status": "pass",
       "detail": "canonical tokens only; legacy aliases deleted",
-      "duration_ms": 146
+      "duration_ms": 255
     },
     {
       "name": "Compact Type Ramp Drives dvui Fonts",
@@ -1628,7 +1634,7 @@
       "category": "Transfers",
       "status": "pass",
       "detail": "gallery-dl backend wired: pure\u2192service\u2192dispatch\u2192history+config. gallery-dl not installed (backend inert \u2014 pure tests cover logic)",
-      "duration_ms": 27
+      "duration_ms": 25
     },
     {
       "name": "VNDB visual-novel catalog",
@@ -1684,14 +1690,14 @@
       "category": "Integration",
       "status": "pass",
       "detail": "302 SFW sources (heancms=13, madara=183, mangathemesia=106); opt-in via installMangaSource + /source/catalog, all route through source_config.install",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "Anti-block scrape fetch",
       "category": "Network",
       "status": "pass",
       "detail": "anti-block fetch wired: pure(isBlocked/needsBrowser, no false-pos) \u2192 scrape_fetch \u2192 bridge fetchhtml on dedicated page; selftest ok",
-      "duration_ms": 65
+      "duration_ms": 59
     },
     {
       "name": "Scrapers routed through anti-block fetch",
@@ -1705,7 +1711,7 @@
       "category": "Integration",
       "status": "pass",
       "detail": "MV3 manifest valid (perms + sidePanel + localhost hosts; side_panel + sidebar_action, no popup); background.ts hits /api/open, /api/ingest, /api/source/add, /api/playpause with Bearer + opens the side panel; content.ts detects Madara/MangaThemesia/HeanCMS/LightNovelWP/ReadWN; remote.zig has /source/add + /playpause + typed ingest; source_config.install",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "name": "Anime video extractors",
@@ -1719,7 +1725,7 @@
       "category": "Player",
       "status": "pass",
       "detail": "DooPlay + AnimeStream engines wired: two tested pure parsers registered + routed (search/details/episodes + embed extraction), DooPlay doo_player_ajax admin-ajax embed chain, AnimeStream .eplister + base64 iframe embed, source_config-gated, episode play \u2192 embed \u2192 playEmbed/resolveEmbed",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "name": "Encrypted content cache",
@@ -1740,7 +1746,14 @@
       "category": "Browse",
       "status": "pass",
       "detail": "infinite scroll wired: Drama/VNDB/Jellyfin/Plex/OPDS/Audiobookshelf/Novels/Radio append next page near bottom; Podcasts left no-op (iTunes Search has no offset cursor); Novels 'readwn' source no-op (POST search, no page field)",
-      "duration_ms": 1
+      "duration_ms": 0
+    },
+    {
+      "name": "Plex restored session loads its library",
+      "category": "Plex",
+      "status": "pass",
+      "detail": "restored token loads the library: fetchSections reachable from the render path, backed-off retry (not a pre-success latch), failure surfaced; stale-append guarded by a generation counter (A->B->A safe)",
+      "duration_ms": 0
     }
   ]
 }

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -54,6 +54,7 @@ from features import (  # noqa: F401
     test_anime_sites,
     test_content_cache,
     test_browse_infinite_scroll,
+    test_plex_restore,
 )
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

A restored Plex token left the tab **permanently blank on every relaunch**. `init()` rehydrates the token and sets `conn_state=.connected`, so `renderContent()` skipped the sign-in panel and drew the "Plex · \<server\>" header — but the only caller of the section fetch was `connect()` (the first-run PIN flow). `fetchSections()` itself had **zero callers**, so `section_count` stayed 0 and the connected-looking library rendered empty.

## Fix

- `renderContent()` triggers the section load when a restored connection has no sections yet.
- Latches on the fetch **succeeding** (an empty library is a successful load), not on `section_count > 0` — the latter would re-curl `/library/sections` every retry window forever against a zero-library server.
- Does **not** latch before success, so a transient failure at launch retries after a backoff instead of blanking the tab for the whole run. `disconnect()` clears the latch so a different account still loads.

## Also closes two stale-append races the old section-index guard missed

- **A→B→A**: re-opening a section mid-fetch resets pagination; the old `section_idx != active_section` check (`0==0`) let the stale window append into the freshly reset list. Added a **view generation** bumped on every switch/reload; workers capture it before spawning and re-check before publishing.
- **Same-frame**: `fetchItems()` set `active_section` on the UI thread but deferred the `is_loading`/cursor reset to the worker, so the same frame's `loadMore()` saw the new section with the old cursor and appended at the wrong offset (a page of titles silently missing, `current_start` stranded). The generation guard can't catch this — `loadMore` reads the generation *after* the bump — so the reset now happens on the UI thread **before** the spawn, claiming `is_loading` synchronously.

## Tests

Decision logic lives in `plex_pure.zig` (`shouldFetchSections`, `workerMayPublish`) so production routes through the tested path. Regression tests cover the blank-tab restore, the zero-library poll, and both stale-append interleavings; a feature test asserts `fetchSections` is actually reachable (the property whose absence *was* the bug) — proven to fail on the pre-fix tree.

**Gate:** `zig build` ✅ · `zig build test` ✅ (12 pure tests) · `python3 tests/test_features.py` → 207 passed / 0 failed.

⚠️ Not yet exercised against a live Plex server (no token available here) — verified structurally via build + unit + regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)