### PR TITLE
feat: consolidate lists data into opal-plugins; repoint app

### DIFF
--- a/plugins-manifest.json
+++ b/plugins-manifest.json
@@ -497,6 +497,17 @@
       "endpoints": {
         "base": "https://api.knaben.org/v1"
       }
+    },
+    {
+      "id": "allanime",
+      "name": "AllAnime",
+      "type": "anime",
+      "version": "1.0.0",
+      "endpoints": {
+        "base": "https://api.allanime.day",
+        "referer": "https://allmanga.to"
+      },
+      "file": "plugins/allanime.json"
     }
   ]
 }

--- a/plugins-manifest.json
+++ b/plugins-manifest.json
@@ -174,7 +174,7 @@
       "type": "anime",
       "version": "1.0.0",
       "endpoints": {
-        "base": "https://raw.githubusercontent.com/debpalash/lists/main"
+        "base": "https://raw.githubusercontent.com/debpalash/opal-plugins/main/lists"
       }
     },
     {
@@ -202,7 +202,7 @@
     },
     {
       "id": "comet",
-      "name": "Comet \u00b7 debrid (Stremio)",
+      "name": "Comet · debrid (Stremio)",
       "type": "stremio",
       "version": "1.0.0",
       "endpoints": {

--- a/src/services/anime.zig
+++ b/src/services/anime.zig
@@ -45,13 +45,12 @@ fn drainPendingTexFrees() void {
 }
 
 // ══════════════════════════════════════════════════════════
-// Anime Tab — allanime.day API integration (built-in, no ani-cli)
-// Trending -> Search → Select → Pick Episode → Stream to MPV
+// Anime Tab — Jikan/AniList metadata + Trending → Search → Select → Pick Episode.
+// Stream resolution runs through resolver.zig (torrents → AllAnime → AnimePahe);
+// AllAnime's endpoint now lives in opal-plugins (id "allanime"), inert until
+// installed, so no source host is hardcoded here.
 // ══════════════════════════════════════════════════════════
 
-const allanime_api = "https://api.allanime.day";
-
-const allanime_refr = "https://allmanga.to";
 const agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/121.0";
 
 // NOTE: state.app.anime.is_loading.load(.acquire) / stream_loading / episodes_loading are plain

--- a/src/services/anime.zig
+++ b/src/services/anime.zig
@@ -441,7 +441,7 @@ pub fn loadTrendingAnime() void {
 }
 
 // ══════════════════════════════════════════════════════════
-// `lists` source plugin — anime index from debpalash/lists
+// `lists` source plugin — anime index from debpalash/opal-plugins (lists/)
 // ══════════════════════════════════════════════════════════
 //
 // ENDPOINT: this is a METADATA source, so it ships with a working default and an
@@ -482,7 +482,9 @@ const LISTS_STAMP_KEY = "anime_lists_fetched_at";
 const LISTS_MAX_BYTES: usize = 4 * 1024 * 1024;
 
 /// Built-in default. An installed `lists` plugin overrides it (see listsBase).
-const LISTS_DEFAULT_BASE = "https://raw.githubusercontent.com/debpalash/lists/main";
+// The id-mapping data was consolidated from debpalash/lists into the
+// opal-plugins repo (lists/ subdir); the old repo is an archived mirror.
+const LISTS_DEFAULT_BASE = "https://raw.githubusercontent.com/debpalash/opal-plugins/main/lists";
 
 /// The installed plugin's endpoint if there is one, else the built-in default.
 ///

--- a/src/services/anime_scraper.zig
+++ b/src/services/anime_scraper.zig
@@ -1,6 +1,10 @@
 const std = @import("std");
 
-pub fn decodeSourceURL(allocator: std.mem.Allocator, encoded: []const u8) ![]u8 {
+/// Decode AllAnime's obfuscated source hash into a playable URL. `base` is the
+/// installed "allanime" endpoint (from source_config) — passed in rather than
+/// hardcoded so no source host lives in the binary; a relative "/..." decode is
+/// joined onto it.
+pub fn decodeSourceURL(allocator: std.mem.Allocator, encoded: []const u8, base: []const u8) ![]u8 {
     var out = std.ArrayListUnmanaged(u8).empty;
     defer out.deinit(allocator);
 
@@ -69,7 +73,7 @@ pub fn decodeSourceURL(allocator: std.mem.Allocator, encoded: []const u8) ![]u8 
     defer allocator.free(res_str);
 
     if (std.mem.startsWith(u8, res_str, "/")) {
-        const full_url = try std.fmt.allocPrint(allocator, "https://api.allanime.day{s}", .{res_str});
+        const full_url = try std.fmt.allocPrint(allocator, "{s}{s}", .{ std.mem.trimEnd(u8, base, "/"), res_str });
         return full_url;
     }
 
@@ -79,7 +83,15 @@ pub fn decodeSourceURL(allocator: std.mem.Allocator, encoded: []const u8) ![]u8 
 test "decoding allanime hash" {
     const alloc = std.testing.allocator;
     const hash = "e2bb4a8d42d3cbb42137d579b28b9c7b2c93b3z52a92a3bbab4fc0d71ba3f07a2w4803z20fa94bf551381274955c42bc8ccdb990a82bcefc62";
-    const decoded = try decodeSourceURL(alloc, hash);
+    const decoded = try decodeSourceURL(alloc, hash, "https://example.test");
     defer alloc.free(decoded);
     try std.testing.expect(decoded.len > 0);
+}
+
+test "decodeSourceURL joins a relative decode onto the passed-in base (no hardcoded host)" {
+    const alloc = std.testing.allocator;
+    // "17" decodes to '/', so this encodes a leading-slash path → joined onto base.
+    const decoded = try decodeSourceURL(alloc, "17", "https://example.test");
+    defer alloc.free(decoded);
+    try std.testing.expect(std.mem.startsWith(u8, decoded, "https://example.test/"));
 }

--- a/src/services/resolver.zig
+++ b/src/services/resolver.zig
@@ -1936,6 +1936,14 @@ fn resolveAnime(query_buf: [256]u8, qlen: usize) void {
 
     const query = query_buf[0..qlen];
 
+    // Endpoint migrated to opal-plugins — inert until the user installs "allanime".
+    // AllAnime is a scrape-class streaming source, the same class as AnimePahe and
+    // the torrent engines, so it ships gated rather than hardcoded in the binary
+    // (unlike the Jikan/AniList metadata APIs). No install → no allanime results.
+    const sc = @import("../core/source_config.zig");
+    const aa_base = sc.get("allanime", "base") orelse return;
+    const aa_referer = sc.get("allanime", "referer") orelse aa_base;
+
     // Escape quotes and backslashes for JSON safety
     var safe_q: [256]u8 = undefined;
     var si: usize = 0;
@@ -1975,13 +1983,13 @@ fn resolveAnime(query_buf: [256]u8, qlen: usize) void {
     const query_enc = @import("../core/http.zig").urlEncode(search_gql, &query_enc_buf);
 
     var final_url_buf: [2048]u8 = undefined;
-    const url = std.fmt.bufPrint(&final_url_buf, "https://api.allanime.day/api?variables={s}&query={s}", .{ vars_enc, query_enc }) catch return;
+    const url = std.fmt.bufPrint(&final_url_buf, "{s}/api?variables={s}&query={s}", .{ std.mem.trimEnd(u8, aa_base, "/"), vars_enc, query_enc }) catch return;
 
     var buf: [64 * 1024]u8 = undefined;
     @import("../core/rate_limit.zig").acquire("allanime", 1.0); // scrape-class — be gentle
     const body = @import("../core/http.zig").fetch(url, &buf, .{
         .timeout_secs = 8,
-        .referer = "https://allmanga.to",
+        .referer = aa_referer,
         .user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/121.0",
     }) orelse return;
     const n = body.len;

--- a/tests/features/test_allanime_gated.py
+++ b/tests/features/test_allanime_gated.py
@@ -1,0 +1,53 @@
+"""AllAnime — gated source endpoint (migrated to opal-plugins).
+
+AllAnime (api.allanime.day / allmanga.to) is the anime search provider in the
+universal resolver. It's a scrape-class streaming source — the same class as
+AnimePahe and the torrent engines, which ship gated behind a plugin install —
+so it must NOT be hardcoded live in the binary the way the Jikan/AniList metadata
+APIs are. This pins the extraction: the endpoint comes from source_config and no
+allanime.day / allmanga.to host literal survives in the source.
+
+See tests/features/harness.py for the shared @test decorator + helpers."""
+from .harness import *  # noqa: F401,F403
+
+import os
+import json as _json
+
+
+@test("AllAnime source is gated via opal-plugins", "Player")
+def test_allanime_gated():
+    resolver = _src("src/services/resolver.zig")
+    anime = _src("src/services/anime.zig")
+    scraper = _src("src/services/anime_scraper.zig")
+
+    problems = []
+
+    # 1) resolver.zig reads the endpoint from source_config, inert when absent.
+    if 'get("allanime", "base")' not in resolver:
+        problems.append("resolver not gated behind source_config allanime base")
+    if 'get("allanime", "referer")' not in resolver:
+        problems.append("resolver does not read the allanime referer from source_config")
+
+    # 2) No source host literal left anywhere in the source (the whole point).
+    for f, src in (("resolver.zig", resolver), ("anime.zig", anime),
+                   ("anime_scraper.zig", scraper)):
+        if "api.allanime.day" in src or "allmanga.to" in src:
+            problems.append(f"{f} still hardcodes an allanime host literal")
+
+    # 3) The decode helper takes the base as a param instead of hardcoding it.
+    if "decodeSourceURL(allocator: std.mem.Allocator, encoded: []const u8, base:" not in scraper:
+        problems.append("decodeSourceURL does not accept an injected base")
+
+    # 4) Manifest entries present (bundled + per-plugin file reference).
+    with open(os.path.join(PROJECT_DIR, "plugins-manifest.json")) as fh:
+        manifest = _json.load(fh)
+    entry = next((p for p in manifest["plugins"] if p["id"] == "allanime"), None)
+    if not (entry and entry.get("type") == "anime"):
+        problems.append("bundled manifest missing allanime entry (type anime)")
+    elif "api.allanime.day" not in entry["endpoints"].get("base", ""):
+        problems.append("allanime manifest entry has no base endpoint")
+
+    if problems:
+        return "fail", "; ".join(problems)
+    return ("pass", "allanime gated: resolver reads source_config base+referer, "
+            "no host literal in source, decodeSourceURL base injected, manifest wired")

--- a/tests/features/test_player.py
+++ b/tests/features/test_player.py
@@ -311,13 +311,15 @@ def test_anime_netflix_experience():
 
 @test("Anime Lists Source Plugin", "Anime")
 def test_anime_lists_plugin():
-    # The debpalash/lists repo (AniList<->MAL id maps + a currently-airing feed)
-    # wired into the anime index. It is a METADATA source, so it ships with a
-    # working default endpoint and an installed `lists` plugin merely OVERRIDES
-    # it. It was originally gated behind a plugin install like a torrent index,
-    # which meant the chip rendered NOTHING on every machine (no plugin ships
-    # installed) -- the neutrality rule is about infringing endpoints, and Jikan
-    # and AniList, the other two anime metadata APIs, are both hardcoded.
+    # AniList<->MAL id maps + a currently-airing feed wired into the anime index.
+    # It is a METADATA source, so it ships with a working default endpoint and an
+    # installed `lists` plugin merely OVERRIDES it. It was originally gated behind
+    # a plugin install like a torrent index, which meant the chip rendered NOTHING
+    # on every machine (no plugin ships installed) -- the neutrality rule is about
+    # infringing endpoints, and Jikan and AniList, the other two anime metadata
+    # APIs, are both hardcoded.
+    # The data was consolidated from the former debpalash/lists repo into
+    # debpalash/opal-plugins (lists/ subdir); the base URL points there now.
     import json as _json
     an = _src("src/services/anime.zig")
     pure = _src("src/services/anime_lists_pure.zig")
@@ -330,13 +332,13 @@ def test_anime_lists_plugin():
         # Registered through the EXISTING source-plugin contract (plugin_repo.zig
         # reads this manifest; install writes ~/.config/opal/plugins/sources/<id>.json).
         "manifest entry": entry is not None and entry.get("type") == "anime",
-        "manifest endpoint": bool(entry and "debpalash/lists" in entry["endpoints"]["base"]),
+        "manifest endpoint": bool(entry and "opal-plugins/main/lists" in entry["endpoints"]["base"]),
         # Plugin can still override the endpoint...
         "source_config override": 'get("lists", "base")' in an,
         # ...but a machine with no plugin installed MUST still get data. A null
         # listsBase() hides the chip entirely, which is the bug this pins.
         "works with no plugin installed": ("LISTS_DEFAULT_BASE" in an
-                                           and "debpalash/lists" in an),
+                                           and "opal-plugins/main/lists" in an),
         # Fetch: curl (never std.http), off the UI thread, into the shared grid.
         "fetches airing feed": "anime-airing.json" in an,
         "curl not std.http": "curl" in an and "std.http" not in an,

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -55,6 +55,7 @@ from features import (  # noqa: F401
     test_content_cache,
     test_browse_infinite_scroll,
     test_plex_restore,
+    test_allanime_gated,
 )
 
 if __name__ == "__main__":


### PR DESCRIPTION
Companion to the opal-plugins changes ([lists merge](https://github.com/debpalash/opal-plugins/commit/f6b5f4c), [type fix](https://github.com/debpalash/opal-plugins/commit/12a3f0f), [allanime entry](https://github.com/debpalash/opal-plugins/commit/4c0326e)).

## 1. Consolidate `lists` data into opal-plugins
The `debpalash/lists` id-map data (AniList↔MAL↔AniDB; `anime-airing.json` + fuller snapshots) moved into `opal-plugins/lists/`. The old repo becomes an archived mirror.
- `LISTS_DEFAULT_BASE` + bundled `plugins-manifest.json` `lists` endpoint repointed at the new raw path (verified live, HTTP 200).
- Behavior unchanged — same file, same SWR cache, same plugin override; only the default host moves.

## 2. Extract AllAnime to opal-plugins (gated source)
`api.allanime.day` / `allmanga.to` — the anime search provider in the universal resolver — was the **one** infringement-class source still hardcoded live, while AnimePahe and every torrent engine already ship gated behind a plugin install. Now consistent with the neutrality rule:
- `resolveAnime()` reads base + referer from `source_config("allanime")`, inert until installed (mirrors the AnimePahe pattern).
- `decodeSourceURL()` takes the base as a parameter — **no allanime host literal survives in the binary**.
- Dead `allanime_api`/`allanime_refr` constants removed.
- `allanime` entry added to the bundled manifest + the opal-plugins repo.

⚠️ **Behavior change:** anime **search via AllAnime** becomes opt-in (install the `allanime` plugin to re-enable). Anime browsing/metadata (Jikan + AniList) and the torrent/AnimePahe playback fallbacks are unaffected.

## Endpoint-extraction audit (why nothing else moved)
Swept all 62 hardcoded external hosts in non-test source. Everything else is correctly placed:
- **Already migrated:** the ~40 torrent/Stremio/scraper endpoints.
- **Deliberately hardcoded per policy:** TMDB, Jikan, AniList, radio-browser, TVmaze/Trakt/Simkl/VNDB/OMDb, and keyless subtitle providers — **MangaDex and Gestdown carry explicit in-code "keyless public API" comments**, so gating them would contradict the maintainer's documented rule.
- **Infra/AI/reference & resolvers:** GitHub/HuggingFace/AI backends/Wikimedia/Plex auth, and the video extractors (which resolve embed links, not user endpoints).

## Tests
- `test_allanime_gated` (new): resolver reads source_config base+referer, no host literal in src, `decodeSourceURL` base injected, manifest entry present.
- `anime_scraper.zig`: new unit test for base injection.
- Existing `Anime Lists Source Plugin` test updated for the new base.

**Gate:** `zig build` ✅ · `zig build test` ✅ · `python3 tests/test_features.py` → **207 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)