### PR TITLE
ci: fix feature-suite + bump to 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.4.1
+
+### Windows
+- **Builds from source on Windows** (MSYS2 MINGW64 + Zig 0.16): the torrent-wrapper build now passes `pkg-config` flags for libtorrent's TLS backend.
+- **Sharp rendering** via an embedded Per-Monitor-V2 DPI manifest (was blurry/upscaled), and **no console window** on launch (GUI subsystem + `CREATE_NO_WINDOW` child spawns).
+- **Custom window title bar**: borderless, in-app min/max/close, native drag / Aero Snap / edge-resize.
+- Opens **centered and non-fullscreen**.
+
+### Fixes & UX
+- Plugins: **Refresh** no longer empties the list, and **install** works for all sources (uses inline endpoints instead of a rate-limited per-plugin fetch).
+- Subtitles: cross-platform cache path + in-process gzip (no `gunzip` dependency).
+- First-run optional-deps "Setup" wizard no longer auto-pops; it's now in Settings › AI & Voice.
+- Responsive top nav (labels collapse to icons, tighter search box as the window narrows).
+- Player: one-click **universal-language** button (audio + subtitle track + subtitle search language together).
+
 ## 0.2.0
 
 ### New sources & media classes

--- a/Formula/opal.rb
+++ b/Formula/opal.rb
@@ -12,10 +12,12 @@ class Opal < Formula
   # publish a compiled arm64 binary with every release, so install that.
   desc "Pure-Zig desktop media browser + AI copilot (dvui + mpv + apfel)"
   homepage "https://github.com/debpalash/Opal"
-  version "0.4.0"
+  version "0.4.1"
   license "GPL-3.0-only"
 
-  url "https://github.com/debpalash/Opal/releases/download/v0.4.0/opal-0.4.0-macos-arm64.tar.gz"
+  url "https://github.com/debpalash/Opal/releases/download/v0.4.1/opal-0.4.1-macos-arm64.tar.gz"
+  # Re-pin to the real v0.4.1 tarball checksum when the release is cut (see the
+  # prior "pin v0.4.0's real tarball checksum" commit for the flow).
   sha256 "0120eac5d9ce12ec57c31fad422b1e22a9a8d4667b84f893fb24a9c31d774cd4"
 
   # The published binary is Apple-silicon only (GitHub retired the Intel runners).

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .opal,
-    .version = "0.4.0",
+    .version = "0.4.1",
     .dependencies = .{
         .dvui = .{
             .url = "git+https://github.com/debpalash/dvui#c2424c15cbfacfe24d66fda4963055eb4c9ee200",

--- a/src/services/updater.zig
+++ b/src/services/updater.zig
@@ -13,7 +13,7 @@ const alloc = @import("../core/alloc.zig").allocator;
 
 /// Current app version. Kept in sync with build.zig.zon + Info.plist
 /// (scripts/build-app.sh derives CFBundleShortVersionString from the zon).
-pub const APP_VERSION: []const u8 = "0.2.0";
+pub const APP_VERSION: []const u8 = "0.4.1";
 
 const RELEASE_API = "https://api.github.com/repos/debpalash/Opal/releases/latest";
 

--- a/tests/features/test_build.py
+++ b/tests/features/test_build.py
@@ -9,7 +9,9 @@ def test_zig_build():
     try:
         result = subprocess.run(
             ["zig", "build"], cwd=PROJECT_DIR,
-            capture_output=True, text=True, timeout=120
+            # Cold CI builds link the C++ torrent wrapper + the whole app; 120s
+            # was right at the edge and flaked. 300s leaves headroom.
+            capture_output=True, text=True, timeout=300
         )
         if result.returncode == 0:
             binary = os.path.join(PROJECT_DIR, "zig-out/bin/opal")

--- a/tests/features/test_page_shell2.py
+++ b/tests/features/test_page_shell2.py
@@ -84,7 +84,7 @@ def test_shell_immersive_navbar():
     sh = _src("src/ui/shell.zig")
     ok = (
         "shouldHideChrome" in sh
-        and "renderTopNav(compact)" in sh
+        and "renderTopNav(compact" in sh   # now takes a responsive `narrow` arg too
         and "if (!immersive)" in sh
         and "nav_alpha" in sh                          # phase 4: nav fades instead of popping
         and "router.current == .player" in sh          # scoped so browsing keeps the nav

--- a/tests/features/test_page_shell3.py
+++ b/tests/features/test_page_shell3.py
@@ -237,12 +237,14 @@ def test_nav_donate_button():
         # A donate chip that spawns its own child process = duplicated launcher.
         "no second launcher": "Child.init(" not in hdr,
         # Room for the chip came from the omnibox cap, not from overlapping it.
-        "omnibox narrowed": ".max_size_content = .{ .w = 640, .h = 26 }" in shell,
+        # The omnibox is now a fixed, responsive width (no .expand), tighter than
+        # the old 640 so the nav row fits the chip + right-side actions.
+        "omnibox narrowed": ".max_size_content = .{ .w = if (narrow)" in shell,
     }
     missing = [k for k, v in checks.items() if not v]
     if missing:
         return "fail", "donate button wiring incomplete: " + ", ".join(missing)
-    return "pass", "donate chip: header.zig → openExternal, omnibox capped at 640"
+    return "pass", "donate chip: header.zig → openExternal, omnibox width-capped"
 
 
 @test("EZTV Release Calendar (neutral + live)", "Page Shell")


### PR DESCRIPTION
Fixes the red `feature-suite` on `main` (from #9) and bumps the version to **0.4.1**.

### CI fixes (4 red tests)
- **Zig Build / Binary Exists** — the 120s cold-build cap flaked (the build was still linking the C++ torrent wrapper, not failing). Raised to 300s.
- **Page Shell Immersive Hides Nav** — pinned the exact string `renderTopNav(compact)`, which now takes a responsive `narrow` arg. Match the prefix.
- **Nav Donate Button** — pinned the old omnibox `max_size_content = 640`; the omnibox is now a fixed, responsive width. Match the new capped form.

### Version
- `build.zig.zon` 0.4.0 → **0.4.1**
- `updater.APP_VERSION` 0.2.0 → **0.4.1** (was stale — shown in Settings › About and used for update checks)
- CHANGELOG 0.4.1 entry for the Windows work

🤖 Generated with [Claude Code](https://claude.com/claude-code)