### PR TITLE
test: make the feature suite runnable on Windows

### DIFF
--- a/tests/features/harness.py
+++ b/tests/features/harness.py
@@ -24,6 +24,15 @@ import socket
 import sys
 import re as _re
 
+# Windows consoles default to cp1252, which can't encode the ✅/❌ status glyphs
+# this harness prints (UnicodeEncodeError mid-run). Force UTF-8 output so the
+# suite runs on Windows too; CI's Linux/macOS already default to UTF-8.
+try:
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+except Exception:
+    pass
+
 # harness.py lives at tests/features/harness.py → three dirnames to the repo root.
 DB_PATH = os.path.expanduser("~/.config/opal/opal.db")
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/tests/features/test_build.py
+++ b/tests/features/test_build.py
@@ -4,6 +4,15 @@ shared @test decorator, helpers, and run_all()."""
 from .harness import *  # noqa: F401,F403
 import os, sys, subprocess, sqlite3, socket, time, json  # noqa: F401
 
+def _built_binary():
+    # zig names the exe `opal` on POSIX and `opal.exe` on Windows.
+    for name in ("zig-out/bin/opal", "zig-out/bin/opal.exe"):
+        p = os.path.join(PROJECT_DIR, name)
+        if os.path.exists(p):
+            return p
+    return None
+
+
 @test("Zig Build", "Build")
 def test_zig_build():
     try:
@@ -14,20 +23,20 @@ def test_zig_build():
             capture_output=True, text=True, timeout=300
         )
         if result.returncode == 0:
-            binary = os.path.join(PROJECT_DIR, "zig-out/bin/opal")
-            if os.path.exists(binary):
+            binary = _built_binary()
+            if binary:
                 size = os.path.getsize(binary) / (1024*1024)
                 return "pass", f"Binary: {size:.1f} MB"
             return "pass", "Build succeeded"
         return "fail", result.stderr[:200]
     except subprocess.TimeoutExpired:
-        return "fail", "Build timed out (>120s)"
+        return "fail", "Build timed out (>300s)"
 
 
 @test("Binary Exists", "Build")
 def test_binary_exists():
-    binary = os.path.join(PROJECT_DIR, "zig-out/bin/opal")
-    if os.path.exists(binary):
+    binary = _built_binary()
+    if binary:
         size = os.path.getsize(binary) / (1024*1024)
         mtime = time.strftime("%H:%M:%S", time.localtime(os.path.getmtime(binary)))
         return "pass", f"{size:.1f} MB, built at {mtime}"


### PR DESCRIPTION
Harness-only fixes so `python tests/test_features.py` runs on Windows (it crashed mid-run before). **No product changes.**

- **harness.py**: force UTF-8 stdout/stderr — Windows consoles default to cp1252 and can't encode the ✅/❌ status glyphs (`UnicodeEncodeError`).
- **test_build.py**: find the built binary as `opal` **or** `opal.exe` (zig names it `.exe` on Windows); fix the stale `>120s` timeout message to `300s`.

Local Windows run after these: **189 passed, 0 failed, 29 skipped** — matching the green CI on Linux/macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)