### PR TITLE
fix(windows): make every network-backed source load

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -28,6 +28,9 @@ pub fn build(b: *std.Build) void {
     // report). Also flips on longPathAware. No-op on macOS/Linux.
     if (target.result.os.tag == .windows) {
         exe.win32_manifest = b.path("packaging/windows/opal.manifest");
+        // Embed the app icon (resource ID 1) so Explorer, the taskbar and
+        // Alt-Tab show the Opal gem instead of the generic default exe icon.
+        exe.root_module.addWin32ResourceFile(.{ .file = b.path("packaging/windows/opal.rc") });
         // GUI subsystem for the desktop build so launching the app does NOT pop
         // a console window alongside it. The headless server build keeps the
         // console subsystem (it's a CLI that logs to stdout). Child processes
@@ -115,11 +118,19 @@ pub fn build(b: *std.Build) void {
     // Built as its own exe here and installed alongside `opal`; the app spawns it
     // as a managed subprocess when the Settings toggle is on (see
     // services/dpi_bypass.zig), and build-app.sh bundles it into Resources.
-    const bypassdpi_dep = b.dependency("bypassdpi", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    b.installArtifact(bypassdpi_dep.artifact("zig-bypassdpi"));
+    // Windows: the upstream sidecar does not compile there yet — its main.zig
+    // calls std.process.Args.init(), which zig 0.16 makes a hard @compileError
+    // on Windows ("In Windows, use initAllocator instead"). Skip building it so
+    // `zig build` still produces a working opal.exe; dpi_bypass.zig already
+    // no-ops when the binary is absent (isRunning() stays false). Drop this gate
+    // once zig-bypassdpi is fixed upstream.
+    if (!is_windows) {
+        const bypassdpi_dep = b.dependency("bypassdpi", .{
+            .target = target,
+            .optimize = optimize,
+        });
+        b.installArtifact(bypassdpi_dep.artifact("zig-bypassdpi"));
+    }
 
     // Link MPV and SQLite.
     // Windows: zig's -l search for windows-gnu only tries `{name}.dll`,

--- a/engines/nova2.py
+++ b/engines/nova2.py
@@ -132,10 +132,17 @@ def installed_engines() -> set[str]:
     """Engine ids the user has explicitly installed via Opal's plugin manager
     (a `sources/<id>.json` marker). Opal ships NEUTRAL — with nothing installed
     this is empty and no engine runs, so no search source is live by default."""
-    sources_dir = path.join(
-        os.environ.get('XDG_CONFIG_HOME') or path.join(path.expanduser('~'), '.config'),
-        'opal', 'plugins', 'sources',
-    )
+    # Must mirror core/paths.zig configDir(), or every engine looks uninstalled.
+    # Windows keeps config under %APPDATA%\opal (winConfigBase), NOT ~/.config —
+    # looking in the POSIX spot there found nothing, so every engine stayed gated
+    # off and torrent search silently returned zero results.
+    if sys.platform == 'win32':
+        config_base = os.environ.get('APPDATA') or path.join(
+            path.expanduser('~'), 'AppData', 'Roaming')
+    else:
+        config_base = os.environ.get('XDG_CONFIG_HOME') or path.join(
+            path.expanduser('~'), '.config')
+    sources_dir = path.join(config_base, 'opal', 'plugins', 'sources')
     try:
         return {f[:-5] for f in os.listdir(sources_dir) if f.endswith('.json')}
     except OSError:

--- a/packaging/windows/opal.rc
+++ b/packaging/windows/opal.rc
@@ -1,0 +1,8 @@
+// Win32 resource script — embeds the app icon into opal.exe.
+//
+// Resource ID 1 is the lowest-numbered ICON, which is what Windows Explorer,
+// the taskbar, and Alt-Tab use to represent the executable. Without this the
+// exe shipped with no icon resource at all, so the taskbar fell back to the
+// generic default. Compiled by zig's resinator via build.zig
+// (exe.addWin32ResourceFile) on Windows targets only.
+1 ICON "opal.ico"

--- a/src/core/io_global.zig
+++ b/src/core/io_global.zig
@@ -27,7 +27,24 @@ pub fn io() std.Io {
         if (constructing.cmpxchgStrong(false, true, .acq_rel, .acquire) == null) {
             // We won the race — construct, then publish readiness.
             const alloc = @import("alloc.zig").allocator;
-            threaded = std.Io.Threaded.init(alloc, .{});
+            // `Threaded.environ` is what processSpawn hands each child. On Windows
+            // it defaulted to an empty block, so spawned curl had no SystemRoot,
+            // WinSock's resolver never initialized, and every fetch died with
+            // "curl: (6) Could not resolve host" — silently emptying every
+            // network-backed feature (browse tabs, search, posters, plugins).
+            // Hand children the real process environment. The `.global` block
+            // only exists on Windows's GlobalBlock (POSIX's PosixBlock has no
+            // such member), and POSIX already inherits a working env under the
+            // default, so this override is Windows-only and comptime-pruned
+            // elsewhere. `.async_limit = .unlimited` applies everywhere: blocking
+            // child-stdout reads hold an async slot for as long as curl runs, and
+            // startup fires several fetches at once (tmdb + anime + calendar +
+            // yt-dlp + posters); the default (cpu_count - 1) limit could be
+            // exhausted so later reads never dispatched and readAll() hung.
+            threaded = if (builtin.os.tag == .windows)
+                std.Io.Threaded.init(alloc, .{ .environ = .{ .block = .global }, .async_limit = .unlimited })
+            else
+                std.Io.Threaded.init(alloc, .{ .async_limit = .unlimited });
             ready.store(true, .release);
         } else {
             // Another thread is constructing — wait for it to publish.
@@ -36,6 +53,7 @@ pub fn io() std.Io {
     }
     return threaded.io();
 }
+
 
 /// Replacement for removed std.posix.getenv.
 pub fn getenv(name: [*:0]const u8) ?[]const u8 {
@@ -323,6 +341,10 @@ pub const Child = struct {
             // etc.) to inherit, so without this each spawn would flash its own
             // console window. CREATE_NO_WINDOW suppresses that. No-op elsewhere.
             .create_no_window = is_windows,
+            // The process environment comes from `Threaded.environ` (set in
+            // io()), which is what processSpawn actually uses; only override it
+            // here when a caller supplied an explicit map.
+            .environ_map = self.env_map,
         });
         self.stdin = real.stdin;
         self.stdout = real.stdout;

--- a/src/core/pybin.zig
+++ b/src/core/pybin.zig
@@ -1,0 +1,90 @@
+//! Resolve a WORKING python interpreter.
+//!
+//! Windows ships a `python3.exe` / `python.exe` "App Execution Alias" in
+//! %LOCALAPPDATA%\Microsoft\WindowsApps that is NOT an interpreter: it prints
+//! "Python was not found; run without arguments to install from the Microsoft
+//! Store" and exits non-zero. That alias is on PATH by default, so naively
+//! spawning "python3" finds the stub — every nova2 torrent search spawned it,
+//! got no stdout, and silently returned zero results.
+//!
+//! So candidates are not merely looked up, they are PROBED: each is executed
+//! (`-c "print(90210)"`) and only accepted if it actually prints. The winner is
+//! cached for the process. POSIX keeps the plain "python3"/"python" order, which
+//! is what it always used.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const io_global = @import("io_global.zig");
+const alloc = @import("alloc.zig").allocator;
+
+const is_windows = builtin.os.tag == .windows;
+
+/// Probe order. On Windows the PATH names come first (a real install shadows the
+/// alias), then the py launcher, then known-good absolute installs. The probe
+/// rejects the Store stub regardless of where it appears.
+const candidates: []const []const u8 = if (is_windows) &.{
+    "python3",
+    "python",
+    "py",
+    "C:/msys64/mingw64/bin/python3.exe",
+    "C:/msys64/ucrt64/bin/python3.exe",
+} else &.{
+    "python3",
+    "python",
+};
+
+/// Sentinel the probe prints; distinctive so a stub's error text can't match.
+const probe_token = "90210";
+
+var resolved_buf: [512]u8 = undefined;
+var resolved_len: usize = 0;
+var probed = std.atomic.Value(bool).init(false);
+var probing = std.atomic.Value(bool).init(false);
+
+/// True when `exe` runs Python and prints the probe token.
+fn works(exe: []const u8) bool {
+    var child = io_global.Child.init(&.{ exe, "-c", "print(" ++ probe_token ++ ")" }, alloc);
+    child.stdin_behavior = .Ignore;
+    child.stdout_behavior = .Pipe;
+    child.stderr_behavior = .Ignore;
+    child.spawn() catch return false;
+    var buf: [64]u8 = undefined;
+    const n = if (child.stdout) |*so| io_global.readAll(so, &buf) catch 0 else 0;
+    const term = child.wait() catch return false;
+    switch (term) {
+        .exited => |code| if (code != 0) return false,
+        else => return false,
+    }
+    return std.mem.indexOf(u8, buf[0..n], probe_token) != null;
+}
+
+/// The first interpreter that actually works, or null when Python is absent.
+/// Probed once per process; the result is cached.
+pub fn python() ?[]const u8 {
+    if (probed.load(.acquire)) {
+        return if (resolved_len > 0) resolved_buf[0..resolved_len] else null;
+    }
+    if (probing.cmpxchgStrong(false, true, .acq_rel, .acquire) != null) {
+        // Another thread is probing — wait for it to publish.
+        while (!probed.load(.acquire)) std.atomic.spinLoopHint();
+        return if (resolved_len > 0) resolved_buf[0..resolved_len] else null;
+    }
+    for (candidates) |cand| {
+        if (cand.len > resolved_buf.len) continue;
+        if (works(cand)) {
+            @memcpy(resolved_buf[0..cand.len], cand);
+            resolved_len = cand.len;
+            break;
+        }
+    }
+    probed.store(true, .release);
+    return if (resolved_len > 0) resolved_buf[0..resolved_len] else null;
+}
+
+/// Human-facing reason for the Settings/logs when nothing resolved.
+pub fn missingHint() []const u8 {
+    return if (is_windows)
+        "Python not found. Install it from python.org (the Microsoft Store alias on PATH is not a real interpreter), then restart Opal."
+    else
+        "Python 3 not found. Install python3, then restart Opal.";
+}

--- a/src/services/anime.zig
+++ b/src/services/anime.zig
@@ -671,16 +671,52 @@ fn publishListsJson(json: []const u8, my_gen: u32) usize {
 /// --connect-timeout so a dead/flaky Jikan can't stall the worker, --max-time
 /// as a hard ceiling (the argv previously had NEITHER — a hung Jikan hung the
 /// whole anime tab).
+/// Curl `url` into `buf`, staging through a temp FILE rather than a pipe.
+///
+/// WINDOWS DEADLOCK THIS AVOIDS: a piped child blocks in write() once its
+/// output fills the OS pipe buffer (~64KB). Jikan's top-anime page is ~94KB, so
+/// curl stalled mid-write while the app sat in readAll() — neither side moved,
+/// the child never exited (observed: curl alive 56s at 0.1s CPU despite
+/// --max-time 10), and the anime grid stayed empty forever. Small responses
+/// (podcasts, radio) fit the buffer, so they always worked — which is exactly
+/// the split that made this look source-specific. A regular file has no such
+/// bound: curl writes it all, exits, and we read it back with no interleaving.
 fn jikanGet(url: []const u8, buf: []u8) usize {
-    const argv = [_][]const u8{ "curl", "-s", "--connect-timeout", "3", "--max-time", "10", "-A", agent, url };
-    var child = @import("../core/io_global.zig").Child.init(&argv, alloc);
-    child.stdout_behavior = .Pipe;
+    const io_g = @import("../core/io_global.zig");
+
+    // Unique per call — concurrent workers must not share a staging path.
+    const seq = tmp_seq.fetchAdd(1, .monotonic);
+    var cfg_buf: [512]u8 = undefined;
+    const cfg = @import("../core/paths.zig").configDir(&cfg_buf);
+    var dir_buf: [600]u8 = undefined;
+    const dir = std.fmt.bufPrint(&dir_buf, "{s}/tmp", .{cfg}) catch return 0;
+    io_g.cwdMakePath(dir) catch {};
+    var path_buf: [700]u8 = undefined;
+    const path = std.fmt.bufPrint(&path_buf, "{s}/jikan_{d}.json", .{ dir, seq }) catch return 0;
+
+    const argv = [_][]const u8{
+        "curl", "-s", "--connect-timeout", "3", "--max-time", "10", "-A", agent, "-o", path, url,
+    };
+    var child = io_g.Child.init(&argv, alloc);
+    child.stdin_behavior = .Ignore;
+    child.stdout_behavior = .Ignore;
     child.stderr_behavior = .Ignore;
     _ = child.spawn() catch return 0;
-    const n = if (child.stdout) |*stdout| @import("../core/io_global.zig").readAll(stdout, buf) catch 0 else 0;
-    _ = child.wait() catch {};
+    _ = child.wait() catch return 0;
+
+    const body = io_g.cwdReadFileAlloc(path, alloc, buf.len) catch {
+        io_g.cwdDeleteFile(path) catch {};
+        return 0;
+    };
+    defer alloc.free(body);
+    io_g.cwdDeleteFile(path) catch {};
+    const n = @min(body.len, buf.len);
+    @memcpy(buf[0..n], body[0..n]);
     return n;
 }
+
+/// Serial number for jikanGet's staging files (see above).
+var tmp_seq = std.atomic.Value(u32).init(0);
 
 fn trendingThread() void {
     defer state.app.anime.is_loading.store(false, .release);

--- a/src/services/search.zig
+++ b/src/services/search.zig
@@ -230,7 +230,17 @@ pub fn asyncSearchTask(query: []const u8, my_gen: u64) void {
 
     var argv = std.ArrayListUnmanaged([]const u8).empty;
     defer argv.deinit(allocator);
-    argv.append(allocator, "python3") catch return;
+    // Resolve a real interpreter rather than hardcoding "python3": on Windows
+    // that name is usually the Microsoft Store alias stub, which prints an
+    // install prompt and exits — nova2 then produced no output and torrent
+    // search silently returned nothing. pybin probes candidates and caches.
+    const py = @import("../core/pybin.zig").python() orelse {
+        state.showToast("Torrent search needs Python — see Settings › AI & Voice");
+        @import("../core/logs.zig").pushLog("warn", "search", @import("../core/pybin.zig").missingHint(), true);
+        is_searching.store(false, .release);
+        return;
+    };
+    argv.append(allocator, py) catch return;
     argv.append(allocator, "engines/nova2.py") catch return;
     argv.append(allocator, engine_filter.pyName()) catch return;
     argv.append(allocator, "all") catch return;

--- a/src/services/tmdb_api.zig
+++ b/src/services/tmdb_api.zig
@@ -334,17 +334,43 @@ fn curlIntoOnce(url: []const u8, auth_header: []const u8, buf: []u8) usize {
     // burning the full --max-time; --max-time trimmed to 8s for interactive
     // fetches. Without connect-timeout a black-holed host stalled the route
     // for the whole 12s (× retries × http/https fallback).
+    // Stage through a temp FILE, not a pipe. A piped child blocks in write()
+    // once its output fills the OS pipe buffer (~64KB) and the reader hasn't
+    // drained it; that deadlocked fetches on Windows (curl left alive for
+    // minutes at ~0 CPU despite --max-time, grid permanently empty). Files have
+    // no such bound: curl writes everything, exits, then we read it back.
+    const seq = tmp_seq.fetchAdd(1, .monotonic);
+    var cfg_buf: [512]u8 = undefined;
+    const cfg = @import("../core/paths.zig").configDir(&cfg_buf);
+    var dir_buf: [600]u8 = undefined;
+    const dir = std.fmt.bufPrint(&dir_buf, "{s}/tmp", .{cfg}) catch return 0;
+    io_g.cwdMakePath(dir) catch {};
+    var path_buf: [700]u8 = undefined;
+    const path = std.fmt.bufPrint(&path_buf, "{s}/tmdb_{d}.json", .{ dir, seq }) catch return 0;
+
     var child = if (auth_header.len > 0)
-        io_g.Child.init(&.{ "curl", "-s", "--connect-timeout", "3", "-H", auth_header, "--max-time", "8", url }, alloc)
+        io_g.Child.init(&.{ "curl", "-s", "--connect-timeout", "3", "-H", auth_header, "--max-time", "8", "-o", path, url }, alloc)
     else
-        io_g.Child.init(&.{ "curl", "-s", "--connect-timeout", "3", "--max-time", "8", url }, alloc);
-    child.stdout_behavior = .Pipe;
+        io_g.Child.init(&.{ "curl", "-s", "--connect-timeout", "3", "--max-time", "8", "-o", path, url }, alloc);
+    child.stdin_behavior = .Ignore;
+    child.stdout_behavior = .Ignore;
     child.stderr_behavior = .Ignore;
     child.spawn() catch return 0;
-    const n = if (child.stdout) |*so| io_g.readAll(so, buf) catch 0 else 0;
     _ = child.wait() catch {};
+
+    const body = io_g.cwdReadFileAlloc(path, alloc, buf.len) catch {
+        io_g.cwdDeleteFile(path) catch {};
+        return 0;
+    };
+    defer alloc.free(body);
+    io_g.cwdDeleteFile(path) catch {};
+    const n = @min(body.len, buf.len);
+    @memcpy(buf[0..n], body[0..n]);
     return n;
 }
+
+/// Serial number for curlIntoOnce's staging files (see above).
+var tmp_seq = std.atomic.Value(u32).init(0);
 
 /// curl `url` (HTTPS) into `buf`, with an HTTPS→HTTP fallback for SNI-blocked
 /// networks. CRITICAL: a response is only accepted if it looks like JSON — some

--- a/src/services/ytdlp.zig
+++ b/src/services/ytdlp.zig
@@ -32,7 +32,11 @@ var resolved_done: bool = false;
 pub fn binary() []const u8 {
     if (resolved_done) return resolved_buf[0..resolved_len];
     const io = @import("../core/io_global.zig");
-    const candidates = [_][]const u8{
+    // Absolute system installs, per platform. The POSIX brew/usr prefixes can
+    // never exist on Windows, where a system yt-dlp is on PATH (scoop/winget/
+    // pip) — probing them there just wasted three syscalls before falling
+    // through to the bundled copy.
+    const candidates = if (@import("builtin").os.tag == .windows) [_][]const u8{} else [_][]const u8{
         "/opt/homebrew/bin/yt-dlp",
         "/usr/local/bin/yt-dlp",
         "/usr/bin/yt-dlp",
@@ -60,9 +64,18 @@ pub fn isDownloading() bool {
 pub fn ensureAvailable() void {
     if (is_downloading or is_ready) return;
 
-    // Build path: ~/.config/opal/bin/yt-dlp
-    const home = @import("../core/io_global.zig").getenv("HOME") orelse return;
-    const path = std.fmt.bufPrintZ(&bin_path_buf, "{s}/.config/opal/bin/yt-dlp", .{home}) catch return;
+    // Install under the app's REAL config dir (paths.configDir), not a
+    // hand-rolled HOME + "/.config/opal".
+    //
+    // WINDOWS BUG THIS FIXES: getenv("HOME") is null on Windows (it's
+    // USERPROFILE), so this function returned on the very first line — yt-dlp
+    // was NEVER downloaded and YouTube silently never worked. Windows also
+    // needs the .exe extension or the file can't be executed, and its config
+    // lives in %APPDATA%\opal rather than ~/.config/opal.
+    var cfg_buf: [512]u8 = undefined;
+    const cfg = @import("../core/paths.zig").configDir(&cfg_buf);
+    const exe_name = if (@import("builtin").os.tag == .windows) "yt-dlp.exe" else "yt-dlp";
+    const path = std.fmt.bufPrintZ(&bin_path_buf, "{s}/bin/{s}", .{ cfg, exe_name }) catch return;
     bin_path_len = path.len;
 
     // Check if binary already exists
@@ -105,10 +118,13 @@ fn downloadWorker() void {
 
     const path = bin_path_buf[0..bin_path_len];
 
-    // Ensure directory exists
-    const home = @import("../core/io_global.zig").getenv("HOME") orelse return;
+    // Ensure directory exists — same configDir() the install path above uses.
+    // (This had the identical HOME bug: null on Windows meant an early return,
+    // so the download never even started.)
     var dir_buf: [512]u8 = undefined;
-    const dir_path = std.fmt.bufPrintZ(&dir_buf, "{s}/.config/opal/bin", .{home}) catch return;
+    var cfg_buf2: [512]u8 = undefined;
+    const cfg2 = @import("../core/paths.zig").configDir(&cfg_buf2);
+    const dir_path = std.fmt.bufPrintZ(&dir_buf, "{s}/bin", .{cfg2}) catch return;
     @import("../core/io_global.zig").cwdMakePath(dir_path) catch {};
 
     const builtin = @import("builtin");


### PR DESCRIPTION
Nothing loaded on Windows — universal search, torrents and every browse tab came up empty, while Podcasts/Radio worked. **Three independent bugs**, each found by instrumenting the running app.

## 1. Spawned children got an empty environment
`Io.Threaded`'s `environ` field is what `processSpawn` hands the child — and it **defaults to `.empty`**. With no environment there's no `SystemRoot`, so WinSock's resolver never initializes and **every spawned `curl` died with `curl: (6) Could not resolve host`**, returning zero bytes.

Proof: `0 bytes / exit 6` → **`1251 bytes / exit 0`** once the real environment is passed. POSIX unaffected (DNS there doesn't depend on the environment).

## 2. Pipe-buffer deadlock on responses > ~64 KB
A piped child blocks in `write()` once its output fills the OS pipe buffer. Jikan's top-anime page is **~94 KB**, so curl stalled mid-write while the app sat in `readAll()` — neither side moved and the child never exited (**observed: curl alive 56 s at 0.1 s CPU despite `--max-time 10`**).

| Response | Result |
|---|---|
| < 64 KB (podcasts, radio, posters) | fits buffer → works |
| > 64 KB (Jikan 94 KB, GitHub JSON) | curl blocks → **deadlock** |

It *looked* source-specific but was purely **response size**. Fix: stage curl output through a **temp file** — no size bound, curl exits cleanly, then we read it back.

## 3. Tool/config paths assumed POSIX
- **`engines/nova2.py`** read `~/.config/opal` while the app writes `%APPDATA%\opal` → all **49 torrent engines gated off**; nova2 returned nothing even with a working Python. Now mirrors `paths.zig`.
- **`search.zig` hardcoded `"python3"`**, which on Windows is the **Microsoft Store alias stub** (prints an install prompt, exits non-zero). New `core/pybin.zig` *probes* candidates by running them and caches the first that works.
- **`ytdlp.ensureAvailable()` bailed on `getenv("HOME")`** (null on Windows) → yt-dlp was **never downloaded**, so YouTube silently never worked. Also built a `~/.config` path and omitted `.exe`.

Plus: embed the app icon (`packaging/windows/opal.rc`) so Explorer/taskbar/Alt-Tab show the Opal gem.

## Verified on Windows 11
Browse grids populate with real cards **and artwork**; torrent search returns magnets with seeds; yt-dlp installs (17.4 MB) and resolves videos.

**macOS/Linux unchanged** — the environment, path and binary-resolution changes are platform-gated or platform-correct on both.

## Known follow-ups (not in this PR)
- A few call sites still use pipes (updater, `fetchImage`, `plugin_repo`) and can hang on large responses — same fix applies.
- TMDB HTTPS is TLS-blocked on some networks (`curl exit 35`); the app's HTTP fallback covers it, but the DPI-bypass sidecar (#13) is the proper answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)