### PR TITLE
fix(net): enable DPI-bypass sidecar on Windows

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -118,19 +118,14 @@ pub fn build(b: *std.Build) void {
     // Built as its own exe here and installed alongside `opal`; the app spawns it
     // as a managed subprocess when the Settings toggle is on (see
     // services/dpi_bypass.zig), and build-app.sh bundles it into Resources.
-    // Windows: the upstream sidecar does not compile there yet — its main.zig
-    // calls std.process.Args.init(), which zig 0.16 makes a hard @compileError
-    // on Windows ("In Windows, use initAllocator instead"). Skip building it so
-    // `zig build` still produces a working opal.exe; dpi_bypass.zig already
-    // no-ops when the binary is absent (isRunning() stays false). Drop this gate
-    // once zig-bypassdpi is fixed upstream.
-    if (!is_windows) {
-        const bypassdpi_dep = b.dependency("bypassdpi", .{
-            .target = target,
-            .optimize = optimize,
-        });
-        b.installArtifact(bypassdpi_dep.artifact("zig-bypassdpi"));
-    }
+    // Built for every target now — the sidecar compiles on Windows since
+    // zig-bypassdpi switched argv parsing to iterateAllocator (the old
+    // std.process.Args.iterate() was a hard @compileError on Windows).
+    const bypassdpi_dep = b.dependency("bypassdpi", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    b.installArtifact(bypassdpi_dep.artifact("zig-bypassdpi"));
 
     // Link MPV and SQLite.
     // Windows: zig's -l search for windows-gnu only tries `{name}.dll`,

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -11,8 +11,8 @@
             .hash = "icons-0.1.0-iJxA-VrGMwAVIStBxqDPFeC3wdnANtYyDrNfYXNz95OW",
         },
         .bypassdpi = .{
-            .url = "git+https://github.com/debpalash/zig-bypassdpi#91618501a08f487655e2ac08074f2ccf99db1867",
-            .hash = "zig_bypassdpi-0.1.0-B1zpWKG2AAA86E-OyWtOjBE-zvSvzx2rGMWy3yIA-lEX",
+            .url = "git+https://github.com/debpalash/zig-bypassdpi#4fad7f6b340c89ffdcee4845850e39d04766b628",
+            .hash = "zig_bypassdpi-0.1.0-B1zpWLK3AAB8dEz0DqoVx8yGkR2IwlRsk2WD-wyrqcbF",
         },
     },
     .minimum_zig_version = "0.15.2",


### PR DESCRIPTION
Follow-up to the DPI-bypass work: makes it functional on **Windows** (it previously no-op'd there).

## Root cause
The `zig-bypassdpi` sidecar didn't compile on Windows — its argv parsing used `std.process.Args.iterate()`, a hard `@compileError` on Windows/WASI in Zig 0.16 ("use initAllocator instead"). So #15 had gated it behind `!is_windows`.

## Fix
- **[debpalash/zig-bypassdpi@4fad7f6](https://github.com/debpalash/zig-bypassdpi/commit/4fad7f6)** — switched to the portable `iterateAllocator(gpa)` (+ `defer deinit`). Cross-compiles clean for x86_64/aarch64-windows and x86_64-linux; macOS still builds, tests, and proxies HTTPS (200).
- **Here** — bump the pinned dependency to that commit and remove the `!is_windows` build gate, so the sidecar is built for every target.

## Verified
`zig build` ✅ (opal + zig-bypassdpi) · `zig build test` ✅ · feature suite **212/0** · the bypassdpi dependency **cross-compiles for x86_64-windows with 0 errors** as an Opal artifact.

⚠️ The full Opal Windows *link* needs MinGW mpv/sqlite and isn't reproducible from macOS — but the sidecar compile blocker (the whole reason it was gated) is resolved and verified. Opal's Windows CI only runs `zig build test` (doesn't build the artifact), so this specific path is proven by the cross-compile above rather than by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)