### PR TITLE
feat(ui): collapsible media-type groups for the Browse rail

### DIFF
--- a/src/ui/drawer.zig
+++ b/src/ui/drawer.zig
@@ -56,6 +56,131 @@ const TRANSPARENT: dvui.Color = .{ .r = 0, .g = 0, .b = 0, .a = 0 };
 var drawer_open_seq: usize = 0;
 var drawer_was_open: bool = false;
 
+// ── Source groups (collapsible accordion) ───────────────────────────────────
+// The Sources section grew to ~15 stacked icons. Fold them into media-type
+// groups so the rail stays short: each group is a header icon that expands to
+// reveal its sources inline. The group holding the active tab is always shown.
+const RailGroup = enum { movies_tv, video, anime, reading, audio, web };
+const rail_group_count = @typeInfo(RailGroup).@"enum".fields.len;
+var group_expanded = [_]bool{false} ** rail_group_count;
+
+/// Which group a source tab belongs to (null = not a grouped source, e.g. a
+/// Find-&-Manage or Configure tab that stays top-level). This switch is the
+/// single source of truth the feature test asserts every source is covered by.
+fn groupOf(tab: state.DrawerTab) ?RailGroup {
+    return switch (tab) {
+        .TMDB, .Drama, .Jellyfin, .Plex => .movies_tv,
+        .YouTube => .video,
+        .Anime, .Comics => .anime,
+        .Novels, .Vndb, .Opds => .reading,
+        .Podcasts, .Radio, .Audiobooks => .audio,
+        .Web, .RSS => .web,
+        else => null,
+    };
+}
+
+fn groupLabel(g: RailGroup) []const u8 {
+    return switch (g) {
+        .movies_tv => "Movies & TV",
+        .video => "Video",
+        .anime => "Anime",
+        .reading => "Reading",
+        .audio => "Audio",
+        .web => "Web",
+    };
+}
+
+fn groupIcon(g: RailGroup) []const u8 {
+    const l = icons.tvg.lucide;
+    return switch (g) {
+        .movies_tv => l.film,
+        .video => l.youtube,
+        .anime => l.tv,
+        .reading => l.@"library-big",
+        .audio => l.podcast,
+        .web => l.globe,
+    };
+}
+
+/// Render one collapsible group: a header icon that toggles expansion, then its
+/// source tabs when open. The group containing the active tab is force-expanded
+/// so the current source is always reachable without a click.
+fn renderGroup(g: RailGroup, gi: usize) void {
+    const shell = @import("shell.zig");
+    const contains_active = if (groupOf(state.app.drawer_tab)) |ag| ag == g else false;
+    if (contains_active) group_expanded[gi] = true;
+    const open = group_expanded[gi];
+
+    // Header row: group icon (accent-tinted when it holds the active tab) + a
+    // chevron cue. Clicking toggles the group.
+    {
+        var row = dvui.box(@src(), .{ .dir = .horizontal }, .{
+            .id_extra = 4200 + gi,
+            .expand = .horizontal,
+            .min_size_content = .{ .w = RAIL_W - 2 * RAIL_SIDE_PAD, .h = BTN_SIZE },
+            .margin = .{ .x = RAIL_SIDE_PAD, .y = ICON_GAP / 2, .w = RAIL_SIDE_PAD, .h = ICON_GAP / 2 },
+        });
+        defer row.deinit();
+        var wd: dvui.WidgetData = undefined;
+        if (dvui.buttonIcon(@src(), "", groupIcon(g), .{}, .{}, .{
+            .data_out = &wd,
+            .id_extra = 4200 + gi,
+            .color_fill = TRANSPARENT,
+            .color_fill_hover = theme.colors.bg_hover,
+            .color_text = if (contains_active) theme.colors.accent else theme.colors.text_secondary,
+            .border = dvui.Rect.all(0),
+            .corner_radius = RADIUS_SM,
+            .padding = dvui.Rect.all((BTN_SIZE - ICON_GLYPH) / 2),
+            .min_size_content = .{ .w = BTN_SIZE, .h = BTN_SIZE },
+            .max_size_content = .{ .w = BTN_SIZE, .h = BTN_SIZE },
+            .gravity_x = 0.5,
+            .gravity_y = 0.5,
+        })) {
+            group_expanded[gi] = !group_expanded[gi];
+        }
+        // Chevron cue (down = open, right = closed), dim + small at the edge.
+        _ = dvui.icon(@src(), "chev", if (open) icons.tvg.lucide.@"chevron-down" else icons.tvg.lucide.@"chevron-right", .{}, .{
+            .id_extra = 4200 + gi,
+            .min_size_content = .{ .w = 10, .h = 10 },
+            .color_text = theme.colors.text_tertiary,
+            .gravity_y = 0.5,
+        });
+        components.tipId(@src(), wd, groupLabel(g), 4200 + gi);
+    }
+
+    if (!open) return;
+    // Sources for this group (compact labels; ids kept distinct per tab).
+    switch (g) {
+        .movies_tv => {
+            renderRailTab(.TMDB, shell.iconForTab(.TMDB), "Movies & TV", 4);
+            renderRailTab(.Drama, shell.iconForTab(.Drama), "Drama", 21);
+            renderRailTab(.Jellyfin, shell.iconForTab(.Jellyfin), "Jellyfin", 12);
+            renderRailTab(.Plex, shell.iconForTab(.Plex), "Plex", 13);
+        },
+        .video => {
+            renderRailTab(.YouTube, shell.iconForTab(.YouTube), "YouTube", 5);
+        },
+        .anime => {
+            renderRailTab(.Anime, shell.iconForTab(.Anime), "Anime", 6);
+            renderRailTab(.Comics, shell.iconForTab(.Comics), "Comics", 9);
+        },
+        .reading => {
+            renderRailTab(.Novels, shell.iconForTab(.Novels), "Novels", 20);
+            renderRailTab(.Vndb, shell.iconForTab(.Vndb), "Visual Novels", 22);
+            renderRailTab(.Opds, shell.iconForTab(.Opds), "Books", 17);
+        },
+        .audio => {
+            renderRailTab(.Podcasts, shell.iconForTab(.Podcasts), "Podcasts", 7);
+            renderRailTab(.Radio, shell.iconForTab(.Radio), "Radio", 8);
+            renderRailTab(.Audiobooks, shell.iconForTab(.Audiobooks), "Audiobooks", 18);
+        },
+        .web => {
+            renderRailTab(.Web, shell.iconForTab(.Web), "Web", 10);
+            renderRailTab(.RSS, shell.iconForTab(.RSS), "RSS", 11);
+        },
+    }
+}
+
 pub fn renderDrawer() void {
     if (!state.app.drawer_open) {
         drawer_was_open = false;
@@ -232,28 +357,10 @@ pub fn renderDrawer() void {
 
         railGroupGap(0);
 
-        // ── Group 2: Sources ──
-        renderRailTab(.TMDB, shell.iconForTab(.TMDB), "TMDB", 4);
-        renderRailTab(.YouTube, shell.iconForTab(.YouTube), "YouTube", 5);
-        renderRailTab(.Anime, shell.iconForTab(.Anime), "Anime", 6);
-        // id 21 — distinct high id so concurrent tab additions merge cleanly
-        // (keyboard order lands it after the sources group, which is fine).
-        renderRailTab(.Drama, shell.iconForTab(.Drama), "Asian Drama", 21);
-        renderRailTab(.Podcasts, shell.iconForTab(.Podcasts), "Podcasts", 7);
-        renderRailTab(.Radio, shell.iconForTab(.Radio), "Radio", 8);
-        renderRailTab(.Comics, shell.iconForTab(.Comics), "Comics", 9);
-        // id 20 (not 10) so Novels never shares a widget id with the Web tab —
-        // inserted without renumbering the rest so concurrent tab additions merge
-        // cleanly. Keyboard order puts it after the sources group, which is fine.
-        renderRailTab(.Novels, shell.iconForTab(.Novels), "Novels", 20);
-        // id 21 (not renumbering the rest) so concurrent tab additions merge cleanly.
-        renderRailTab(.Vndb, shell.iconForTab(.Vndb), "Visual Novels", 21);
-        renderRailTab(.Web, shell.iconForTab(.Web), "Web", 10);
-        renderRailTab(.RSS, shell.iconForTab(.RSS), "RSS", 11);
-        renderRailTab(.Jellyfin, shell.iconForTab(.Jellyfin), "Jellyfin / Emby", 12);
-        renderRailTab(.Plex, shell.iconForTab(.Plex), "Plex", 13);
-        renderRailTab(.Audiobooks, shell.iconForTab(.Audiobooks), "Audiobookshelf", 17);
-        renderRailTab(.Opds, shell.iconForTab(.Opds), "Reading (OPDS)", 17);
+        // ── Group 2: Sources (collapsible media-type groups) ──
+        inline for (.{ RailGroup.movies_tv, .video, .anime, .reading, .audio, .web }, 0..) |g, gi| {
+            renderGroup(g, gi);
+        }
 
         railGroupGap(1);
 

--- a/tests/features/test_browse_rail_groups.py
+++ b/tests/features/test_browse_rail_groups.py
@@ -1,0 +1,50 @@
+"""Browse rail — collapsible media-type groups.
+
+The Sources rail grew to ~15 stacked icons. They're now folded into 6
+collapsible media-type groups (Movies & TV / Video / Anime / Reading / Audio /
+Web); each group is a header icon that expands to reveal its sources, and the
+group holding the active tab is force-expanded. This pins that structure so a
+new source tab can't silently fall out of every group.
+
+See tests/features/harness.py for the shared @test decorator."""
+from .harness import *  # noqa: F401,F403
+
+import re
+
+
+# Every source tab that must live inside exactly one rail group.
+SOURCE_TABS = [
+    "TMDB", "Drama", "Jellyfin", "Plex", "YouTube", "Anime", "Comics",
+    "Novels", "Vndb", "Opds", "Podcasts", "Radio", "Audiobooks", "Web", "RSS",
+]
+
+
+@test("Browse rail groups every source", "UI Standards")
+def test_browse_rail_groups():
+    dr = _src("src/ui/drawer.zig")
+
+    checks = {
+        "RailGroup enum (6 media groups)": (
+            "const RailGroup = enum { movies_tv, video, anime, reading, audio, web }" in dr
+        ),
+        "accordion state": "group_expanded" in dr and "rail_group_count" in dr,
+        "collapsible render": "fn renderGroup(" in dr and "renderGroup(g, gi)" in dr,
+        "active group force-expanded": "if (contains_active) group_expanded[gi] = true;" in dr,
+        "chevron open/closed cue": (
+            'lucide.@"chevron-down"' in dr and 'lucide.@"chevron-right"' in dr
+        ),
+        "flat source list removed": '"Asian Drama"' not in dr and '"Reading (OPDS)"' not in dr,
+        "compact labels": '"Drama"' in dr and '"Books"' in dr and '"Jellyfin"' in dr,
+    }
+
+    # Every source tab appears in the groupOf() switch (i.e. is grouped). We check
+    # the switch body specifically so a stray mention elsewhere can't pass it.
+    m = re.search(r"fn groupOf\(tab: state\.DrawerTab\) \?RailGroup \{.*?\n\}", dr, re.S)
+    group_of = m.group(0) if m else ""
+    for t in SOURCE_TABS:
+        checks[f"{t} is grouped"] = bool(re.search(r"\." + t + r"\b", group_of))
+
+    missing = [k for k, v in checks.items() if not v]
+    if missing:
+        return "fail", "rail grouping incomplete: " + ", ".join(missing)
+    return "pass", "15 sources folded into 6 collapsible groups; active group auto-expands"

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -58,6 +58,7 @@ from features import (  # noqa: F401
     test_allanime_gated,
     test_plugins_logs_ui,
     test_dpi_bypass,
+    test_browse_rail_groups,
 )
 
 if __name__ == "__main__":


### PR DESCRIPTION
The Sources rail had grown to ~15 stacked icons. This folds them into **6 collapsible media-type groups**, so the rail stays short.

## Groups
| Group | Sources |
|---|---|
| Movies & TV | TMDB, Drama, Jellyfin, Plex |
| Video | YouTube *(IPTV lands here next)* |
| Anime | Anime, Comics |
| Reading | Novels, Visual Novels, Books (OPDS) |
| Audio | Podcasts, Radio, Audiobooks |
| Web | Web, RSS |

Each group is a header icon with a chevron cue (down = open, right = closed); clicking toggles it, and the group holding the **active tab is force-expanded** so the current source is always reachable without a click. Labels compacted too ("Asian Drama"→"Drama", "Jellyfin / Emby"→"Jellyfin", "Reading (OPDS)"→"Books", "Audiobookshelf"→"Audiobooks").

`groupOf()` is the single source of truth for tab→group; the new feature test asserts **every** source tab is covered, so a future tab can't silently fall out of all groups.

**Gate:** `zig build` ✅ · `zig build test` ✅ · feature suite **213/0** (incl. the no-emoji check).

First of two — IPTV (a new source in the Video group) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)