### PR TITLE
feat(iptv): Live TV source (iptv-org) in the Video group

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -497,6 +497,17 @@ pub fn build(b: *std.Build) void {
     });
     test_step.dependOn(&b.addRunArtifact(test_radio_pure).step);
 
+    // Live TV / IPTV: iptv-org streams.json parsing, m3u8 recognition, the
+    // NSFW/accept gate, the query filter, and the <base>/streams.json builder.
+    const test_iptv_pure = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/services/iptv_pure.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    test_step.dependOn(&b.addRunArtifact(test_iptv_pure).step);
+
     // DPI-bypass sidecar: mode validation, the "127.0.0.1:<port>" builder, and
     // the enabled&&running proxy gate. dpi_bypass.zig routes through these.
     const test_dpi_bypass_pure = b.addTest(.{

--- a/plugins-manifest.json
+++ b/plugins-manifest.json
@@ -508,6 +508,16 @@
         "referer": "https://allmanga.to"
       },
       "file": "plugins/allanime.json"
+    },
+    {
+      "id": "iptv-org",
+      "name": "IPTV (iptv-org)",
+      "type": "iptv",
+      "version": "1.0.0",
+      "endpoints": {
+        "base": "https://iptv-org.github.io/api"
+      },
+      "file": "plugins/iptv-org.json"
     }
   ]
 }

--- a/src/core/state.zig
+++ b/src/core/state.zig
@@ -8,6 +8,7 @@ const thumbnail = @import("../player/thumbnail.zig");
 const subtitles_mod = @import("../player/subtitles.zig");
 const podcasts_pure = @import("../services/podcasts_pure.zig");
 const radio_pure = @import("../services/radio_pure.zig");
+const iptv_pure = @import("../services/iptv_pure.zig");
 const audiobookshelf_pure = @import("../services/audiobookshelf_pure.zig");
 const opds_pure = @import("../services/opds_pure.zig");
 const anime_schedule_pure = @import("../services/anime_schedule_pure.zig");
@@ -19,7 +20,7 @@ const anime_schedule_pure = @import("../services/anime_schedule_pure.zig");
 pub const GridMode = enum { auto, cols_1, cols_2, cols_3, cols_4 };
 pub const ContentProvider = enum { mpv, comic_viewer };
 pub const VideoFillMode = enum { fit, cover };
-pub const DrawerTab = enum { Search, Downloads, TMDB, YouTube, Queue, Comics, Anime, Podcasts, Radio, History, RSS, Jellyfin, Plex, Plugins, Logs, Settings, AI, Web, Audiobooks, Opds, Novels, Vndb, Drama };
+pub const DrawerTab = enum { Search, Downloads, TMDB, YouTube, Queue, Comics, Anime, Podcasts, Radio, History, RSS, Jellyfin, Plex, Plugins, Logs, Settings, AI, Web, Audiobooks, Opds, Novels, Vndb, Drama, Iptv };
 pub const SettingsTab = enum { General, Playback, Network, Subtitles, Storage, Scripts, AI, LangLearn, FileAssoc, About };
 pub const TmdbView = enum { Trending, Search, Favorites, Watchlist, Watching };
 pub const TmdbCategory = enum { trending, now_playing, top_rated, upcoming, popular };
@@ -953,6 +954,29 @@ pub const AppState = struct {
         result_count: usize = 0,
     } = .{},
 
+    // ── Live TV / IPTV (iptv-org streams.json → HLS/m3u8 stream via mpv) ──
+    // The VIDEO twin of `radio`: search → channel list → play. streams.json is a
+    // single static array, so the worker parses ALL accepted channels up front
+    // into this fixed buffer (capped at 300) and infinite scroll reveals them
+    // progressively. Parsing + the NSFW/accept gate live in
+    // services/iptv_pure.zig; the fetch worker publishes here under iptv.zig's
+    // parse_mutex. Opt-in via the source_config-gated "iptv-org" plugin. See
+    // services/iptv.zig.
+    iptv: struct {
+        search_buf: [256]u8 = std.mem.zeroes([256]u8),
+        // Atomic like the radio/podcasts loaders: read by the UI + remote API
+        // threads, written by the detached fetch worker. A plain bool is a race.
+        is_loading: std.atomic.Value(bool) = .init(false),
+        fetch_error: bool = false,
+        // True while results[] holds the full popular directory rather than a
+        // user search — drives the grid heading only.
+        showing_popular: bool = false,
+        // Fixed array (never reallocated) — the channel cap. 300 keeps the parse
+        // bounded so we never hold the ~4 MB feed as parsed objects.
+        results: [300]iptv_pure.IptvChannel = std.mem.zeroes([300]iptv_pure.IptvChannel),
+        result_count: usize = 0,
+    } = .{},
+
     // ── Novels (light-novel / web-novel reader) ──
     // Drill: search → novel → chapter list → paged text reader. Structural
     // sibling of `comic`, but renders TEXT, not page images. Search results and
@@ -1413,6 +1437,10 @@ pub fn navigateToTabNow(tab: DrawerTab) void {
         },
         .Radio => {
             app.browse_source = .Radio;
+            app.router.navigate(.browse);
+        },
+        .Iptv => {
+            app.browse_source = .Iptv;
             app.router.navigate(.browse);
         },
         .Comics => {

--- a/src/services/iptv.zig
+++ b/src/services/iptv.zig
@@ -1,0 +1,602 @@
+//! Live TV (IPTV) tab — the VIDEO twin of radio.zig. Keyless channel discovery
+//! via the iptv-org public directory (streams.json), streamed straight through
+//! mpv (HLS/m3u8/.ts play natively). All parsing + the accept/NSFW decisions
+//! live in iptv_pure.zig (tested); this module owns the async fetch worker,
+//! thread-safety, the SWR disk cache, and dvui rendering.
+//!
+//! Opt-in: the endpoint is source_config-gated (plugin id "iptv-org"). No plugin
+//! installed → iptvBase() is null → the tab is INERT (empty, no fetch). Once the
+//! bundled iptv-org plugin is installed it supplies the base URL (default
+//! https://iptv-org.github.io/api) and the tab lights up.
+//!
+//! streams.json is a single ~4 MB static array (NOT server-paginated), so we
+//! stream-parse it ONCE into a bounded fixed buffer (state.app.iptv.results,
+//! capped at 300 channels) and free the body immediately — never holding the
+//! whole feed as parsed objects. Infinite scroll is therefore PROGRESSIVE
+//! REVEAL: all accepted channels are parsed up front (≤ cap), then loadMore()
+//! reveals the next window as you scroll — no extra fetch, no retained body.
+//!
+//! Flow:
+//!   loadPopularOnce() → curl <base>/streams.json → pure.parseStreams (query="")
+//!                       → results[]. Fires once per session so the page opens
+//!                       populated (SWR-seeded from disk first for instant paint).
+//!   searchIptv(q)     → same fetch, pure.parseStreams(query=q) title-filter.
+//!   playChannel(i)    → browser.loadContentDirectMeta(url) → mpv.
+
+const std = @import("std");
+const dvui = @import("dvui");
+const icons = @import("icons");
+const state = @import("../core/state.zig");
+const theme = @import("../ui/theme.zig");
+const logs = @import("../core/logs.zig");
+const pure = @import("iptv_pure.zig");
+const io = @import("../core/io_global.zig");
+const rate_limit = @import("../core/rate_limit.zig");
+const source_config = @import("../core/source_config.zig");
+const safeUtf8Buf = @import("../core/text.zig").safeUtf8Buf;
+
+const alloc = @import("../core/alloc.zig").allocator;
+
+const agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0";
+
+// ══════════════════════════════════════════════════════════
+// Opt-in gate (source_config, plugin id "iptv-org")
+// ══════════════════════════════════════════════════════════
+// Mirrors animepahe/allanime: get("<id>","base") orelse return → INERT until a
+// plugin is installed. When installed but the base is blank, fall back to the
+// public iptv-org default so the tab still works (like lists.zig's default).
+const IPTV_DEFAULT_BASE = "https://iptv-org.github.io/api";
+
+fn iptvBase() ?[]const u8 {
+    const b = source_config.get("iptv-org", "base") orelse return null; // not installed → inert
+    if (b.len > 0) return b;
+    return IPTV_DEFAULT_BASE; // installed but blank → public default
+}
+
+// ══════════════════════════════════════════════════════════
+// Thread-safety
+// ══════════════════════════════════════════════════════════
+// The detached fetch worker publishes into state.app.iptv.* under `parse_mutex`,
+// and a monotonic `search_gen` drops stale results so fast re-searches never
+// show out-of-order data (mirrors radio.zig). `is_loading` is atomic (read by
+// the UI + remote threads, written by the worker).
+var parse_mutex: @import("../core/sync.zig").Mutex = .{};
+var search_gen: std.atomic.Value(u32) = std.atomic.Value(u32).init(0);
+
+// Query snapshot handed to the detached worker (never read the mutable UI
+// search_buf from the thread).
+var query_buf: [256]u8 = undefined;
+var query_len: usize = 0;
+
+// ── Progressive-scroll reveal ──
+// streams.json is one static file, so there is no second page to fetch: the
+// worker parses ALL accepted channels (≤ the fixed 300 cap) in one pass, and
+// infinite scroll simply reveals `visible` more of them per near-bottom scroll.
+// UI-thread only (set on load start, bumped by loadMore, clamped in render).
+const PAGE_SIZE: usize = 90;
+var visible: usize = 0;
+
+/// One-shot latch. renderContent() calls loadPopularOnce every frame; after the
+/// first, this is a single atomic load. Atomic (not a plain bool) because
+/// searchIptv — reachable from the remote-API thread — also arms it.
+var popular_fetched: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
+
+// ══════════════════════════════════════════════════════════
+// SWR on-disk content cache — the popular channel window (mirrors radio.zig).
+// Serialize the fresh list through content_cache_pure and persist it so the next
+// cold start paints instantly instead of a blank box + spinner. results[] is a
+// FIXED [300]IptvChannel array (never reallocated). Only the first popular load
+// is persisted (search results are not). Gated on content_cache_enabled.
+// ══════════════════════════════════════════════════════════
+const content_cache = @import("../core/content_cache.zig");
+const ccp = @import("../core/content_cache_pure.zig");
+const IPTV_CACHE_TTL_S: i64 = @import("browse_cache.zig").TTL_S;
+const IPTV_CACHE_KEY = "iptv:popular";
+const IPTV_BLOB_CAP: usize = 256 * 1024;
+
+fn serializeChannel(w: *ccp.Writer, c: pure.IptvChannel) void {
+    w.blob(c.name[0..@min(c.name_len, c.name.len)]);
+    w.blob(c.url[0..@min(c.url_len, c.url.len)]);
+    w.blob(c.quality[0..@min(c.quality_len, c.quality.len)]);
+}
+
+fn copyField(dst: []u8, len: *usize, src: []const u8) void {
+    const n = @min(src.len, dst.len);
+    @memcpy(dst[0..n], src[0..n]);
+    len.* = n;
+}
+
+/// Reads one channel from `r`; null when the blob is truncated.
+fn deserializeChannel(r: *ccp.Reader) ?pure.IptvChannel {
+    var c = pure.IptvChannel{};
+    copyField(&c.name, &c.name_len, r.blob() orelse return null);
+    copyField(&c.url, &c.url_len, r.blob() orelse return null);
+    copyField(&c.quality, &c.quality_len, r.blob() orelse return null);
+    return c;
+}
+
+/// SWR write — persist the fresh popular list. Called from the worker while it
+/// already holds parse_mutex, so results[]/result_count are stable.
+fn putPopularCache() void {
+    if (!state.app.content_cache_enabled) return;
+    const count = state.app.iptv.result_count;
+    if (count == 0) return;
+    const buf = alloc.alloc(u8, IPTV_BLOB_CAP) catch return;
+    defer alloc.free(buf);
+    var w = ccp.Writer.init(buf);
+    const n: u16 = @intCast(@min(count, state.app.iptv.results.len));
+    w.u16v(n);
+    var i: usize = 0;
+    while (i < n) : (i += 1) serializeChannel(&w, state.app.iptv.results[i]);
+    const blob = w.done() orelse return;
+    content_cache.put(IPTV_CACHE_KEY, blob, IPTV_CACHE_TTL_S);
+}
+
+/// SWR read — seed the popular grid from disk so it paints instantly on cold
+/// start. UI-thread only (from loadPopularOnce), ONLY when results[] is empty.
+fn seedPopularFromCache() void {
+    if (!state.app.content_cache_enabled) return;
+    if (state.app.iptv.result_count != 0) return;
+    const buf = alloc.alloc(u8, IPTV_BLOB_CAP) catch return;
+    defer alloc.free(buf);
+    const hit = content_cache.get(IPTV_CACHE_KEY, buf) orelse return;
+    var r = ccp.Reader.init(hit.bytes);
+    const n = r.u16v() orelse return;
+    parse_mutex.lock();
+    defer parse_mutex.unlock();
+    if (state.app.iptv.result_count != 0) return; // a fetch beat us under the lock
+    var i: usize = 0;
+    while (i < n and i < state.app.iptv.results.len) : (i += 1) {
+        state.app.iptv.results[i] = deserializeChannel(&r) orelse break;
+    }
+    state.app.iptv.result_count = i;
+    if (i > 0) state.app.iptv.showing_popular = true;
+}
+
+// ══════════════════════════════════════════════════════════
+// Popular — the full channel directory (query = "")
+// ══════════════════════════════════════════════════════════
+
+pub fn loadPopularOnce() void {
+    if (popular_fetched.load(.acquire)) return;
+    // Same first-start gate as the other one-shot loaders: wait for config.
+    if (!state.app.config_loaded.load(.acquire)) return;
+    // Inert until the iptv-org plugin is installed — don't latch, so the tab
+    // lights up the moment the user installs it (no restart).
+    if (iptvBase() == null) return;
+    // A search already landed (remote API) — leave it be.
+    if (state.app.iptv.result_count > 0) {
+        popular_fetched.store(true, .release);
+        return;
+    }
+    if (state.app.iptv.is_loading.load(.acquire)) return;
+
+    // SWR seed: paint the last popular list from disk NOW (empty grid only).
+    seedPopularFromCache();
+
+    popular_fetched.store(true, .release);
+    state.app.iptv.showing_popular = true;
+    state.app.iptv.fetch_error = false;
+    state.app.iptv.is_loading.store(true, .release);
+    visible = PAGE_SIZE;
+
+    // Take a generation like a search does, so a user search fired while this
+    // is in flight supersedes it instead of racing it into results[].
+    const my_gen = search_gen.fetchAdd(1, .acq_rel) + 1;
+    query_len = 0; // popular = no query filter
+
+    if (std.Thread.spawn(.{}, fetchWorker, .{ my_gen, false })) |t| {
+        t.detach();
+    } else |_| {
+        state.app.iptv.is_loading.store(false, .release);
+    }
+}
+
+// ══════════════════════════════════════════════════════════
+// Search — title filter over the same streams.json
+// ══════════════════════════════════════════════════════════
+
+pub fn searchIptv(query: []const u8) void {
+    if (query.len == 0) return;
+    if (iptvBase() == null) return; // inert
+
+    state.app.iptv.is_loading.store(true, .release);
+    state.app.iptv.fetch_error = false;
+    state.app.iptv.showing_popular = false;
+    // A search satisfies "page opens with content" — never let the one-shot
+    // popular fetch land on top of the user's results afterwards.
+    popular_fetched.store(true, .release);
+    visible = PAGE_SIZE;
+
+    const my_gen = search_gen.fetchAdd(1, .acq_rel) + 1;
+
+    // Snapshot the query BEFORE spawning — a newer search overwrites query_buf.
+    const n = @min(query.len, query_buf.len);
+    @memcpy(query_buf[0..n], query[0..n]);
+    query_len = n;
+
+    if (std.Thread.spawn(.{}, fetchWorker, .{ my_gen, true })) |t| {
+        t.detach();
+    } else |_| {
+        state.app.iptv.is_loading.store(false, .release);
+    }
+}
+
+/// One fetch + full parse (popular or search). `is_search` picks whether the
+/// snapshotted query filters titles. Runs the whole parse into the fixed
+/// results[] under `search_gen`, so a fresh search supersedes an in-flight one.
+fn fetchWorker(my_gen: u32, is_search: bool) void {
+    defer state.app.iptv.is_loading.store(false, .release);
+
+    const base = iptvBase() orelse return; // inert (plugin uninstalled mid-flight)
+
+    var url_buf: [256]u8 = undefined;
+    const url = pure.buildStreamsUrl(base, &url_buf);
+    if (url.len == 0) return;
+
+    // Re-snapshot the query — a newer search may overwrite query_buf mid-flight.
+    var local_q: [256]u8 = undefined;
+    const qlen = if (is_search) @min(query_len, local_q.len) else 0;
+    if (qlen > 0) @memcpy(local_q[0..qlen], query_buf[0..qlen]);
+
+    // Shared public directory — be a polite citizen. streams.json is a big
+    // static file, so a slow bucket is fine.
+    rate_limit.acquire("iptv-org", 0.5);
+
+    // 16 MiB cap: streams.json is ~4 MB today with headroom to grow. A larger
+    // feed truncates at the buffer edge (a partial last object is harmless —
+    // parseStreams is bounds-safe), never overruns. Heap-allocated inside curl.
+    const body = curl(url, 16 * 1024 * 1024) orelse {
+        state.app.iptv.fetch_error = true;
+        return;
+    };
+    defer alloc.free(body);
+
+    if (search_gen.load(.acquire) != my_gen) return; // superseded while curl ran
+
+    parse_mutex.lock();
+    defer parse_mutex.unlock();
+    if (search_gen.load(.acquire) != my_gen) return; // re-check under lock
+
+    // NSFW: nsfw_allowed is the INVERSE of the app's filter flag. When the
+    // filter is on (default), adult channels are dropped at parse time and can
+    // never render (mirrors anime/vndb SFW gating).
+    const nsfw_allowed = !state.app.nsfw_filter_enabled;
+    const count = pure.parseStreams(body, &state.app.iptv.results, nsfw_allowed, local_q[0..qlen]);
+    state.app.iptv.result_count = count;
+
+    if (count == 0) {
+        if (is_search) {
+            logs.pushLog("info", "iptv", "Live TV search returned no channels", false);
+        } else {
+            state.app.iptv.fetch_error = true;
+            logs.pushLog("info", "iptv", "Live TV directory returned no channels", false);
+        }
+    } else {
+        if (!is_search) putPopularCache();
+        var lb: [64]u8 = undefined;
+        logs.pushLog("info", "iptv", std.fmt.bufPrint(&lb, "Live TV: {d} channels loaded", .{count}) catch "Live TV channels loaded", false);
+    }
+}
+
+// ══════════════════════════════════════════════════════════
+// Infinite scroll — reveal the next window (no fetch; progressive)
+// ══════════════════════════════════════════════════════════
+
+/// Reveal PAGE_SIZE more already-parsed channels. All accepted channels are
+/// parsed up front (streams.json is a single static file, ≤ the fixed cap), so
+/// paging is instant client-side reveal — no request, no retained body. UI
+/// thread only (called from renderResults on near-bottom scroll).
+pub fn loadMore() void {
+    const total = @min(state.app.iptv.result_count, state.app.iptv.results.len);
+    if (visible >= total) return;
+    visible = @min(visible + PAGE_SIZE, total);
+}
+
+// ══════════════════════════════════════════════════════════
+// Play — hand the m3u8 URL straight to mpv (exactly like radio.playStation)
+// ══════════════════════════════════════════════════════════
+
+/// Load channel `idx`'s HLS stream into mpv. The URL is an m3u8/.ts stream mpv
+/// plays natively, so loadContentDirectMeta (no content-type routing) is used —
+/// creating a player if none exists and revealing the player page, with the
+/// channel name + quality shown on the (video-less until the stream connects)
+/// player pane and bottom bar.
+pub fn playChannel(idx: usize) void {
+    if (idx >= state.app.iptv.result_count) return;
+    const ch = &state.app.iptv.results[idx];
+    const src = ch.url[0..ch.url_len];
+    if (src.len == 0) return;
+
+    // Snapshot the now-playing fields into locals BEFORE playing — a concurrent
+    // re-search can overwrite results[] mid-frame, so nothing handed to
+    // loadContentDirectMeta may alias the live row.
+    var url_buf: [512]u8 = undefined;
+    const ulen = @min(src.len, url_buf.len);
+    @memcpy(url_buf[0..ulen], src[0..ulen]);
+
+    var name_buf: [160]u8 = undefined;
+    const nlen = @min(ch.name_len, name_buf.len);
+    @memcpy(name_buf[0..nlen], ch.name[0..nlen]);
+
+    // Subtitle: "1080p · HLS" — quality (when present) + an HLS tag for m3u8.
+    var sub_buf: [64]u8 = undefined;
+    var sw = std.Io.Writer.fixed(&sub_buf);
+    var wrote = false;
+    if (ch.quality_len > 0) {
+        sw.writeAll(ch.quality[0..@min(ch.quality_len, ch.quality.len)]) catch {};
+        wrote = true;
+    }
+    if (pure.isM3u8(url_buf[0..ulen])) {
+        if (wrote) sw.writeAll(" · ") catch {};
+        sw.writeAll("HLS") catch {};
+        wrote = true;
+    }
+    const sub = sub_buf[0..sw.end];
+
+    @import("browser.zig").loadContentDirectMeta(url_buf[0..ulen], "", name_buf[0..nlen], sub);
+    logs.pushLog("info", "iptv", "Streaming live TV channel", false);
+}
+
+// ══════════════════════════════════════════════════════════
+// Helpers
+// ══════════════════════════════════════════════════════════
+
+/// Fetch `url` with curl into a fresh heap buffer of `cap` bytes. Returns the
+/// filled slice (caller frees) or null on failure/empty. Large buffers stay off
+/// the worker stack (macOS 512KB limit). Shrinks to what was read so the global
+/// DebugAllocator's free-size check passes (an invalid free aborts the process).
+fn curl(url: []const u8, cap: usize) ?[]u8 {
+    const argv = [_][]const u8{ "curl", "-sL", "-A", agent, "--max-time", "30", url };
+    var child = io.Child.init(&argv, alloc);
+    child.stdout_behavior = .Pipe;
+    child.stderr_behavior = .Ignore;
+    _ = child.spawn() catch return null;
+
+    const buf = alloc.alloc(u8, cap) catch {
+        _ = child.wait() catch {};
+        return null;
+    };
+    const n = if (child.stdout) |*so| io.readAll(so, buf) catch 0 else 0;
+    _ = child.wait() catch {};
+    if (n == 0) {
+        alloc.free(buf);
+        return null;
+    }
+    return alloc.realloc(buf, n) catch {
+        alloc.free(buf);
+        return null;
+    };
+}
+
+// ══════════════════════════════════════════════════════════
+// UI (Drawer / Browse › Live TV)
+// ══════════════════════════════════════════════════════════
+
+pub fn renderContent() void {
+    var pageroot = dvui.box(@src(), .{ .dir = .vertical }, .{ .expand = .both });
+    defer pageroot.deinit();
+
+    // Populate the page on first open (no-op after the first fetch / when inert).
+    loadPopularOnce();
+
+    renderSearchBar();
+
+    if (state.app.iptv.fetch_error) {
+        _ = dvui.label(@src(), "Failed to fetch — check your connection", .{}, .{
+            .color_text = theme.colors.danger,
+            .padding = .{ .x = 12, .y = 8, .w = 0, .h = 0 },
+        });
+    }
+
+    renderResults();
+}
+
+fn renderSearchBar() void {
+    var row = dvui.box(@src(), .{ .dir = .horizontal }, .{
+        .expand = .horizontal,
+        .padding = .{ .x = 8, .y = 8, .w = 8, .h = 8 },
+        .background = true,
+        .color_fill = theme.colors.bg_surface,
+    });
+    defer row.deinit();
+
+    _ = dvui.icon(@src(), "", icons.tvg.lucide.@"monitor-play", .{}, .{
+        .color_text = theme.colors.accent,
+        .min_size_content = theme.iconSize(.md),
+        .gravity_y = 0.5,
+        .margin = .{ .x = 0, .y = 0, .w = 6, .h = 0 },
+    });
+
+    var te = dvui.textEntry(@src(), .{
+        .text = .{ .buffer = &state.app.iptv.search_buf },
+        .placeholder = "Search live TV channels...",
+    }, .{
+        .expand = .horizontal,
+        .padding = .{ .x = 6, .y = 4, .w = 6, .h = 4 },
+        .color_fill = theme.colors.bg_elevated,
+        .color_text = theme.colors.text_primary,
+        .corner_radius = theme.dims.rad_sm,
+        .gravity_y = 0.5,
+    });
+    const entered = te.enter_pressed;
+    te.deinit();
+
+    const go = dvui.button(@src(), "Go", .{}, .{
+        .color_fill = theme.colors.accent,
+        .color_text = dvui.Color.white,
+        .corner_radius = theme.dims.rad_sm,
+        .padding = .{ .x = 12, .y = 6, .w = 12, .h = 6 },
+        .margin = .{ .x = 6, .y = 0, .w = 0, .h = 0 },
+        .gravity_y = 0.5,
+    });
+
+    if (entered or go) {
+        const q = std.mem.sliceTo(&state.app.iptv.search_buf, 0);
+        if (q.len > 0) searchIptv(q);
+    }
+
+    if (state.app.iptv.is_loading.load(.acquire)) {
+        _ = dvui.label(@src(), "...", .{}, .{ .color_text = theme.colors.warning, .gravity_y = 0.5 });
+    }
+}
+
+// ── Card grid ──
+// Channels have no logos in streams.json, so cards are a tv glyph + name +
+// "quality · HLS". Click → playChannel(i).
+const CARD_GAP: f32 = 6;
+const CARD_TARGET_W: f32 = 170;
+const CARD_FOOTER_H: f32 = 46;
+
+/// One channel card: tv glyph tile (clickable → play) + name + quality/HLS.
+fn renderCard(i: usize, card_w: f32) void {
+    const ch = &state.app.iptv.results[i];
+
+    // Validate a STABLE COPY: a fetch worker can rewrite results[i] mid-frame
+    // and dvui panics on invalid UTF-8 it reads after we validated.
+    var name_buf: [160]u8 = undefined;
+    const name = safeUtf8Buf(ch.name[0..@min(ch.name_len, ch.name.len)], &name_buf);
+
+    var card = dvui.box(@src(), .{ .dir = .vertical }, .{
+        .id_extra = i,
+        .min_size_content = .{ .w = card_w, .h = card_w + CARD_FOOTER_H },
+        .max_size_content = .{ .w = card_w, .h = card_w + CARD_FOOTER_H },
+        .margin = dvui.Rect.all(CARD_GAP),
+    });
+    defer card.deinit();
+
+    // Glyph tile hosted INSIDE a single button widget — one clickable rectangle.
+    {
+        var bw: dvui.ButtonWidget = undefined;
+        bw.init(@src(), .{}, .{
+            .id_extra = i + 2000,
+            .background = true,
+            .color_fill = theme.colors.bg_elevated,
+            .corner_radius = dvui.Rect.all(8),
+            .min_size_content = .{ .w = card_w, .h = card_w },
+            .max_size_content = .{ .w = card_w, .h = card_w },
+            .padding = dvui.Rect.all(0),
+        });
+        bw.processEvents();
+        bw.drawBackground();
+
+        _ = dvui.icon(@src(), "", icons.tvg.lucide.tv, .{}, .{
+            .id_extra = i + 1000,
+            .color_text = theme.colors.text_tertiary,
+            .gravity_x = 0.5,
+            .gravity_y = 0.5,
+            .expand = .both,
+        });
+
+        const clicked = bw.clicked();
+        bw.drawFocus();
+        bw.deinit();
+        if (clicked) playChannel(i);
+    }
+
+    _ = dvui.label(@src(), "{s}", .{name}, .{
+        .id_extra = i + 3000,
+        .color_text = theme.colors.text_primary,
+        .expand = .horizontal,
+        .padding = .{ .x = 2, .y = 4, .w = 2, .h = 0 },
+    });
+
+    // Meta: quality · HLS.
+    var meta_buf: [48]u8 = undefined;
+    var mw = std.Io.Writer.fixed(&meta_buf);
+    var wrote = false;
+    if (ch.quality_len > 0) {
+        mw.writeAll(ch.quality[0..@min(ch.quality_len, ch.quality.len)]) catch {};
+        wrote = true;
+    }
+    if (pure.isM3u8(ch.url[0..ch.url_len])) {
+        if (wrote) mw.writeAll(" · ") catch {};
+        mw.writeAll("HLS") catch {};
+        wrote = true;
+    }
+    if (wrote) {
+        var safe_meta: [48]u8 = undefined;
+        _ = dvui.label(@src(), "{s}", .{safeUtf8Buf(meta_buf[0..mw.end], &safe_meta)}, .{
+            .id_extra = i + 4000,
+            .color_text = theme.colors.text_tertiary,
+            .expand = .horizontal,
+            .padding = .{ .x = 2, .y = 0, .w = 2, .h = 0 },
+        });
+    }
+}
+
+fn renderResults() void {
+    const total = @min(state.app.iptv.result_count, state.app.iptv.results.len);
+    if (total == 0) {
+        if (state.app.iptv.is_loading.load(.acquire)) {
+            _ = dvui.label(@src(), "Loading channels...", .{}, .{
+                .color_text = theme.colors.text_secondary,
+                .padding = .{ .x = 12, .y = 20, .w = 0, .h = 0 },
+            });
+        } else if (iptvBase() == null) {
+            // Inert — no plugin installed.
+            _ = dvui.label(@src(), "Install the IPTV (iptv-org) plugin to enable Live TV", .{}, .{
+                .color_text = theme.colors.text_secondary,
+                .padding = .{ .x = 12, .y = 20, .w = 0, .h = 0 },
+            });
+        } else {
+            _ = dvui.label(@src(), "No channels found", .{}, .{
+                .color_text = theme.colors.text_secondary,
+                .padding = .{ .x = 12, .y = 20, .w = 0, .h = 0 },
+            });
+        }
+        return;
+    }
+
+    // Clamp the reveal window to what's actually parsed.
+    const shown = @min(@max(visible, PAGE_SIZE), total);
+
+    var scroll = dvui.scrollArea(@src(), .{}, .{
+        .expand = .both,
+        .background = true,
+        .color_fill = theme.colors.bg_surface,
+    });
+    defer scroll.deinit();
+
+    _ = dvui.label(@src(), "{s}", .{
+        if (state.app.iptv.showing_popular) "Live TV channels" else "Results",
+    }, .{
+        .color_text = theme.colors.text_secondary,
+        .padding = .{ .x = 8, .y = 8, .w = 8, .h = 2 },
+    });
+
+    // Responsive columns from the LIVE page width (one-frame lag; first paint
+    // falls back to a sane default) — same shape as radio's grid.
+    const rect_w = scroll.data().rect.w;
+    const avail_w: f32 = @max(240, (if (rect_w > 1) rect_w else 900) - 8);
+    const cols: usize = @max(2, @as(usize, @intFromFloat(avail_w / CARD_TARGET_W)));
+    const cols_f: f32 = @floatFromInt(cols);
+    const card_w: f32 = @max(100, (avail_w - cols_f * 2 * CARD_GAP) / cols_f);
+
+    var r: usize = 0;
+    while (r * cols < shown) : (r += 1) {
+        var row = dvui.box(@src(), .{ .dir = .horizontal }, .{
+            .id_extra = r + 50000,
+            .expand = .horizontal,
+        });
+        defer row.deinit();
+
+        var col: usize = 0;
+        while (col < cols and r * cols + col < shown) : (col += 1) renderCard(r * cols + col, card_w);
+    }
+
+    // Progressive infinite scroll: reveal the next window as the user nears the
+    // bottom. No fetch — everything is already parsed, so this is an instant
+    // client-side reveal (mirrors radio's near-bottom trigger without the async
+    // append worker). `underfilled` keeps revealing when the first window is
+    // shorter than the viewport.
+    if (shown < total) {
+        const max_y = scroll.si.scrollMax(.vertical);
+        const near_bottom = max_y > 0 and scroll.si.viewport.y >= max_y - 800;
+        const underfilled = max_y <= 0;
+        if (near_bottom or underfilled) {
+            loadMore();
+            dvui.refresh(null, @src(), null);
+        }
+    }
+}

--- a/src/services/iptv_pure.zig
+++ b/src/services/iptv_pure.zig
@@ -1,0 +1,402 @@
+//! Pure parsing + decisions for the Live TV (IPTV) tab — the VIDEO twin of
+//! radio_pure.zig. No app-state / dvui / atomics imports, so the logic ships
+//! tested (registered as `test_iptv_pure` in build.zig).
+//!
+//! Data source: the iptv-org public directory `streams.json` — a flat JSON
+//! array of stream objects:
+//!   https://iptv-org.github.io/api/streams.json
+//!   [{ "channel":null, "feed":null, "title":"Milennio TV",
+//!      "url":"https://…/milenniotv.m3u8", "quality":"720p",
+//!      "label":null, "user_agent":null, "referrer":null }, …]
+//!
+//! `url` is the playable HLS/m3u8 stream (mpv plays it natively). `channel`
+//! links to channels.json (categories + is_nsfw) but is often null and adds a
+//! second ~10 MB fetch, so v1 does NOT enrich country/group from it — those
+//! fields exist on the record but stay empty. NSFW is gated heuristically from
+//! the title/url instead (see isNsfw), since streams.json alone carries no
+//! is_nsfw flag.
+//!
+//! The parser writes into a caller-provided fixed-buffer slice and returns the
+//! number of channels filled — bounds-safe on a worker thread (a malformed feed
+//! must never trip a slice panic → a worker panic aborts the whole app).
+
+const std = @import("std");
+
+// ── Fixed-buffer record (shared with state.zig; no dvui/atomics so std.mem.zeroes works). ──
+
+pub const IptvChannel = struct {
+    // Channel display name (streams.json `title`).
+    name: [160]u8 = std.mem.zeroes([160]u8),
+    name_len: usize = 0,
+    // The playable HLS/m3u8 stream URL handed straight to mpv.
+    url: [512]u8 = std.mem.zeroes([512]u8),
+    url_len: usize = 0,
+    // Quality label ("720p"/"1080p"/…); may be empty.
+    quality: [8]u8 = std.mem.zeroes([8]u8),
+    quality_len: usize = 0,
+    // Optional enrichment from channels.json — LEFT EMPTY in v1 (single-file
+    // fetch only). Present so the record is forward-compatible.
+    country: [64]u8 = std.mem.zeroes([64]u8),
+    country_len: usize = 0,
+    group: [64]u8 = std.mem.zeroes([64]u8),
+    group_len: usize = 0,
+};
+
+// ══════════════════════════════════════════════════════════
+// Shared JSON helpers (mirrors radio_pure.zig)
+// ══════════════════════════════════════════════════════════
+
+/// Decode the common JSON string escapes (\" \\ \/ \n \r \t \uXXXX) from `src`
+/// into `dst`, returning bytes written (bounded by dst.len). iptv-org escapes
+/// URL slashes as "\/", which would otherwise leave a broken stream URL.
+/// Anything not a recognized escape is copied verbatim so we never corrupt.
+pub fn jsonUnescape(src: []const u8, dst: []u8) usize {
+    var out: usize = 0;
+    var i: usize = 0;
+    while (i < src.len and out < dst.len) {
+        const ch = src[i];
+        if (ch != '\\' or i + 1 >= src.len) {
+            dst[out] = ch;
+            out += 1;
+            i += 1;
+            continue;
+        }
+        switch (src[i + 1]) {
+            '"' => {
+                dst[out] = '"';
+                out += 1;
+                i += 2;
+            },
+            '\\' => {
+                dst[out] = '\\';
+                out += 1;
+                i += 2;
+            },
+            '/' => {
+                dst[out] = '/';
+                out += 1;
+                i += 2;
+            },
+            'n' => {
+                dst[out] = '\n';
+                out += 1;
+                i += 2;
+            },
+            'r' => {
+                dst[out] = '\r';
+                out += 1;
+                i += 2;
+            },
+            't' => {
+                dst[out] = '\t';
+                out += 1;
+                i += 2;
+            },
+            'u' => {
+                if (i + 6 <= src.len) {
+                    if (std.fmt.parseInt(u21, src[i + 2 .. i + 6], 16)) |cp| {
+                        var u8b: [4]u8 = undefined;
+                        const n = std.unicode.utf8Encode(cp, &u8b) catch 0;
+                        if (n > 0 and out + n <= dst.len) {
+                            @memcpy(dst[out .. out + n], u8b[0..n]);
+                            out += n;
+                        }
+                        i += 6;
+                    } else |_| {
+                        dst[out] = '\\';
+                        out += 1;
+                        i += 1;
+                    }
+                } else {
+                    dst[out] = '\\';
+                    out += 1;
+                    i += 1;
+                }
+            },
+            else => {
+                dst[out] = '\\';
+                out += 1;
+                i += 1;
+            },
+        }
+    }
+    return out;
+}
+
+/// Find `key` (e.g. `"title":"`) in `scope`, then read the JSON string value up
+/// to the next unescaped `"`, decoding escapes into `dst`. Returns bytes
+/// written, or 0 if the key is absent (or its value is `null`, which has no
+/// opening quote). Bounds-safe against a truncated value.
+fn jsonStrField(scope: []const u8, key: []const u8, dst: []u8) usize {
+    const at = std.mem.indexOf(u8, scope, key) orelse return 0;
+    const start = at + key.len;
+    var end = start;
+    var esc = false;
+    while (end < scope.len) : (end += 1) {
+        if (esc) {
+            esc = false;
+        } else if (scope[end] == '\\') {
+            esc = true;
+        } else if (scope[end] == '"') {
+            break;
+        }
+    }
+    if (end > scope.len) return 0;
+    return jsonUnescape(scope[start..@min(end, scope.len)], dst);
+}
+
+// ══════════════════════════════════════════════════════════
+// Pure decisions (URL shape, m3u8 recognition, NSFW gate, query match)
+// ══════════════════════════════════════════════════════════
+
+/// True when `url` is an http/https stream mpv can open directly.
+pub fn isHttpUrl(url: []const u8) bool {
+    return std.mem.startsWith(u8, url, "http://") or std.mem.startsWith(u8, url, "https://");
+}
+
+/// Case-insensitive substring test.
+fn containsCI(haystack: []const u8, needle: []const u8) bool {
+    if (needle.len == 0) return true;
+    if (needle.len > haystack.len) return false;
+    var i: usize = 0;
+    while (i + needle.len <= haystack.len) : (i += 1) {
+        var j: usize = 0;
+        while (j < needle.len) : (j += 1) {
+            if (std.ascii.toLower(haystack[i + j]) != std.ascii.toLower(needle[j])) break;
+        } else return true;
+    }
+    return false;
+}
+
+/// Recognize an HLS/m3u8 playlist URL (path ends in `.m3u8`/`.m3u`, ignoring a
+/// trailing `?query`/`#fragment`). Surfaced as an "HLS" badge in the UI, so the
+/// tested logic is the shipped logic. mpv also plays non-m3u8 http streams, so
+/// this is a display hint, NOT the accept gate (that's isHttpUrl).
+pub fn isM3u8(url: []const u8) bool {
+    var path = url;
+    if (std.mem.indexOfScalar(u8, path, '?')) |q| path = path[0..q];
+    if (std.mem.indexOfScalar(u8, path, '#')) |h| path = path[0..h];
+    return std.mem.endsWith(u8, path, ".m3u8") or std.mem.endsWith(u8, path, ".m3u");
+}
+
+/// Heuristic adult-content detector over the title + url. streams.json carries
+/// no is_nsfw flag (that lives in channels.json, a separate ~10 MB file this v1
+/// does not fetch), so the gate keys on explicit adult tokens. Deliberately
+/// conservative to avoid false positives on benign names like "Adult Swim" or
+/// "Adult Animation" — plain "adult" is NOT a trigger; only explicit tokens are.
+pub fn isNsfw(title: []const u8, url: []const u8) bool {
+    const tokens = [_][]const u8{
+        "xxx",     "porn",  "brazzers", "playboy", "hustler",
+        "penthouse", "hentai", "camsoda", "chaturbate", "redtube",
+        "18+",     "adults only",
+    };
+    for (tokens) |t| {
+        if (containsCI(title, t)) return true;
+        if (containsCI(url, t)) return true;
+    }
+    return false;
+}
+
+/// Case-insensitive title filter for search. Empty query matches everything (so
+/// the popular/all-channels load reuses the same accept path).
+pub fn matchesQuery(title: []const u8, query: []const u8) bool {
+    return containsCI(title, query);
+}
+
+/// Whole accept decision for one stream entry, routed from parseStreams so the
+/// tested logic IS the shipped logic:
+///   • a non-empty display name, AND
+///   • a playable http(s) URL, AND
+///   • passes the NSFW gate (unless `nsfw_allowed`), AND
+///   • matches the (possibly empty) search query.
+pub fn acceptEntry(title: []const u8, url: []const u8, quality: []const u8, nsfw_allowed: bool, query: []const u8) bool {
+    _ = quality; // reserved (kept in the signature so callers pass full context)
+    if (title.len == 0) return false;
+    if (!isHttpUrl(url)) return false;
+    if (!nsfw_allowed and isNsfw(title, url)) return false;
+    if (!matchesQuery(title, query)) return false;
+    return true;
+}
+
+// ══════════════════════════════════════════════════════════
+// URL builder
+// ══════════════════════════════════════════════════════════
+
+/// `<base>/streams.json` for the installed iptv-org endpoint. A trailing slash
+/// on `base` is trimmed so we never emit `//streams.json`. Returns "" only if
+/// `dst` is too small.
+pub fn buildStreamsUrl(base: []const u8, dst: []u8) []const u8 {
+    const trimmed = std.mem.trimEnd(u8, base, "/");
+    return std.fmt.bufPrint(dst, "{s}/streams.json", .{trimmed}) catch "";
+}
+
+// ══════════════════════════════════════════════════════════
+// streams.json → channels
+// ══════════════════════════════════════════════════════════
+
+/// Parse an iptv-org streams.json array into `out`, keeping the first
+/// `out.len` entries that pass acceptEntry (playable URL, name, NSFW gate,
+/// query filter). `query` is a case-insensitive title filter ("" = all).
+/// `nsfw_allowed` lifts the adult gate. Each stream object is delimited by its
+/// `"channel":` marker (present once per object, even when its value is null).
+/// Returns the number of channels written (≤ out.len). Bounds-safe on any
+/// malformed / truncated feed.
+pub fn parseStreams(json: []const u8, out: []IptvChannel, nsfw_allowed: bool, query: []const u8) usize {
+    var count: usize = 0;
+    var pos: usize = 0;
+    const marker = "\"channel\":";
+    while (pos < json.len and count < out.len) {
+        const idx = std.mem.indexOfPos(u8, json, pos, marker) orelse break;
+        // Object scope: this marker to the next object's marker (or EOF), so
+        // field reads never bleed into a neighbouring object.
+        const scan_from = idx + marker.len;
+        var obj_end = json.len;
+        if (std.mem.indexOfPos(u8, json, scan_from, marker)) |nidx| obj_end = nidx;
+        const obj = json[idx..obj_end];
+        pos = obj_end;
+
+        var c = &out[count];
+        c.* = .{};
+
+        c.url_len = jsonStrField(obj, "\"url\":\"", &c.url);
+        c.name_len = jsonStrField(obj, "\"title\":\"", &c.name);
+        c.quality_len = jsonStrField(obj, "\"quality\":\"", &c.quality);
+
+        if (!acceptEntry(
+            c.name[0..c.name_len],
+            c.url[0..c.url_len],
+            c.quality[0..c.quality_len],
+            nsfw_allowed,
+            query,
+        )) continue;
+
+        count += 1;
+    }
+    return count;
+}
+
+// ══════════════════════════════════════════════════════════
+// Tests
+// ══════════════════════════════════════════════════════════
+
+test "isHttpUrl accepts http/https only" {
+    try std.testing.expect(isHttpUrl("http://a/x.m3u8"));
+    try std.testing.expect(isHttpUrl("https://a/x.m3u8"));
+    try std.testing.expect(!isHttpUrl("rtmp://a/x"));
+    try std.testing.expect(!isHttpUrl(""));
+}
+
+test "isM3u8 recognizes HLS playlists incl. query/fragment" {
+    try std.testing.expect(isM3u8("https://a/b/index.m3u8"));
+    try std.testing.expect(isM3u8("https://a/b/playlist.m3u8?token=abc"));
+    try std.testing.expect(isM3u8("https://a/b/live.m3u#x"));
+    try std.testing.expect(!isM3u8("https://a/b/stream.ts"));
+    try std.testing.expect(!isM3u8("https://a/b/live.mpd"));
+}
+
+test "isNsfw flags explicit adult tokens but not 'Adult Swim'" {
+    try std.testing.expect(isNsfw("Blue XXX TV", ""));
+    try std.testing.expect(isNsfw("Some Channel", "https://x/porn/live.m3u8"));
+    try std.testing.expect(isNsfw("Hentai Haven", ""));
+    // Regression: benign names containing "adult" must NOT be filtered.
+    try std.testing.expect(!isNsfw("Adult Swim Latin America Brazil", "https://a/as.m3u8"));
+    try std.testing.expect(!isNsfw("Pluto TV Adult Animation", "https://a/pluto.m3u8"));
+    try std.testing.expect(!isNsfw("Stingray Pop Adult", "https://a/s.m3u8"));
+}
+
+test "matchesQuery is a case-insensitive substring; empty = all" {
+    try std.testing.expect(matchesQuery("BBC News HD", "news"));
+    try std.testing.expect(matchesQuery("BBC News HD", "BBC"));
+    try std.testing.expect(matchesQuery("anything", ""));
+    try std.testing.expect(!matchesQuery("BBC News HD", "cnn"));
+}
+
+test "acceptEntry gates name/url/nsfw/query" {
+    // Happy path.
+    try std.testing.expect(acceptEntry("BBC", "https://a/x.m3u8", "720p", false, ""));
+    // No name → reject.
+    try std.testing.expect(!acceptEntry("", "https://a/x.m3u8", "720p", false, ""));
+    // Non-http URL → reject.
+    try std.testing.expect(!acceptEntry("BBC", "rtmp://a/x", "720p", false, ""));
+    // NSFW rejected when filter on, allowed when off.
+    try std.testing.expect(!acceptEntry("XXX Channel", "https://a/x.m3u8", "", false, ""));
+    try std.testing.expect(acceptEntry("XXX Channel", "https://a/x.m3u8", "", true, ""));
+    // Query filter.
+    try std.testing.expect(acceptEntry("BBC News", "https://a/x.m3u8", "", false, "news"));
+    try std.testing.expect(!acceptEntry("BBC News", "https://a/x.m3u8", "", false, "sports"));
+}
+
+test "buildStreamsUrl appends streams.json and trims a trailing slash" {
+    var buf: [128]u8 = undefined;
+    try std.testing.expectEqualStrings(
+        "https://iptv-org.github.io/api/streams.json",
+        buildStreamsUrl("https://iptv-org.github.io/api", &buf),
+    );
+    try std.testing.expectEqualStrings(
+        "https://iptv-org.github.io/api/streams.json",
+        buildStreamsUrl("https://iptv-org.github.io/api/", &buf),
+    );
+    var tiny: [4]u8 = undefined;
+    try std.testing.expectEqualStrings("", buildStreamsUrl("https://a", &tiny));
+}
+
+test "parseStreams extracts title/url/quality from real-shaped JSON" {
+    const json =
+        \\[{"channel":null,"feed":null,"title":"Milennio TV","url":"https:\/\/v.example.com:19360\/milenniotv\/milenniotv.m3u8","quality":"720p","label":null,"user_agent":null,"referrer":null},
+        \\{"channel":"BBCNews.uk","feed":null,"title":"BBC News","url":"https:\/\/b\/news.m3u8","quality":"1080p","label":null}]
+    ;
+    var out: [8]IptvChannel = undefined;
+    const n = parseStreams(json, &out, false, "");
+    try std.testing.expectEqual(@as(usize, 2), n);
+    try std.testing.expectEqualStrings("Milennio TV", out[0].name[0..out[0].name_len]);
+    try std.testing.expectEqualStrings("https://v.example.com:19360/milenniotv/milenniotv.m3u8", out[0].url[0..out[0].url_len]);
+    try std.testing.expectEqualStrings("720p", out[0].quality[0..out[0].quality_len]);
+    try std.testing.expect(isM3u8(out[0].url[0..out[0].url_len]));
+    try std.testing.expectEqualStrings("BBC News", out[1].name[0..out[1].name_len]);
+    try std.testing.expectEqualStrings("1080p", out[1].quality[0..out[1].quality_len]);
+}
+
+test "parseStreams applies the query filter" {
+    const json =
+        \\[{"channel":null,"title":"BBC News","url":"https:\/\/b\/news.m3u8","quality":"1080p"},
+        \\{"channel":null,"title":"ESPN Sports","url":"https:\/\/e\/sport.m3u8","quality":"720p"}]
+    ;
+    var out: [8]IptvChannel = undefined;
+    const n = parseStreams(json, &out, false, "news");
+    try std.testing.expectEqual(@as(usize, 1), n);
+    try std.testing.expectEqualStrings("BBC News", out[0].name[0..out[0].name_len]);
+}
+
+test "parseStreams drops entries with no playable url or no title" {
+    const json =
+        \\[{"channel":null,"title":"No URL","url":null,"quality":"720p"},
+        \\{"channel":null,"title":null,"url":"https:\/\/a\/x.m3u8","quality":"720p"},
+        \\{"channel":null,"title":"Good","url":"https:\/\/a\/y.m3u8","quality":"480p"}]
+    ;
+    var out: [8]IptvChannel = undefined;
+    const n = parseStreams(json, &out, false, "");
+    try std.testing.expectEqual(@as(usize, 1), n);
+    try std.testing.expectEqualStrings("Good", out[0].name[0..out[0].name_len]);
+}
+
+test "parseStreams honours the NSFW gate" {
+    const json =
+        \\[{"channel":null,"title":"XXX Live","url":"https:\/\/a\/xxx.m3u8","quality":"720p"},
+        \\{"channel":null,"title":"Family TV","url":"https:\/\/a\/fam.m3u8","quality":"720p"}]
+    ;
+    var out: [8]IptvChannel = undefined;
+    // Filter ON → only the SFW channel.
+    try std.testing.expectEqual(@as(usize, 1), parseStreams(json, &out, false, ""));
+    try std.testing.expectEqualStrings("Family TV", out[0].name[0..out[0].name_len]);
+    // Filter OFF → both.
+    try std.testing.expectEqual(@as(usize, 2), parseStreams(json, &out, true, ""));
+}
+
+test "parseStreams regression: malformed JSON never panics" {
+    var out: [8]IptvChannel = undefined;
+    try std.testing.expectEqual(@as(usize, 0), parseStreams("", &out, false, ""));
+    try std.testing.expectEqual(@as(usize, 0), parseStreams("[", &out, false, ""));
+    try std.testing.expectEqual(@as(usize, 0), parseStreams("[{\"channel\":", &out, false, ""));
+    _ = parseStreams("\"channel\":null,\"url\":\"https:\\/\\/", &out, false, "");
+    _ = parseStreams("[{\"channel\":null,\"title\":\"n\",\"url\":\"https://a\"}]", &out, false, "");
+}

--- a/src/ui/drawer.zig
+++ b/src/ui/drawer.zig
@@ -70,7 +70,7 @@ var group_expanded = [_]bool{false} ** rail_group_count;
 fn groupOf(tab: state.DrawerTab) ?RailGroup {
     return switch (tab) {
         .TMDB, .Drama, .Jellyfin, .Plex => .movies_tv,
-        .YouTube => .video,
+        .YouTube, .Iptv => .video,
         .Anime, .Comics => .anime,
         .Novels, .Vndb, .Opds => .reading,
         .Podcasts, .Radio, .Audiobooks => .audio,
@@ -159,6 +159,7 @@ fn renderGroup(g: RailGroup, gi: usize) void {
         },
         .video => {
             renderRailTab(.YouTube, shell.iconForTab(.YouTube), "YouTube", 5);
+            renderRailTab(.Iptv, shell.iconForTab(.Iptv), "Live TV", 23);
         },
         .anime => {
             renderRailTab(.Anime, shell.iconForTab(.Anime), "Anime", 6);
@@ -429,6 +430,7 @@ pub fn renderTabContent(tab: state.DrawerTab) void {
         .Drama => @import("../services/drama.zig").renderContent(),
         .Podcasts => @import("../services/podcasts.zig").renderContent(),
         .Radio => @import("../services/radio.zig").renderContent(),
+        .Iptv => @import("../services/iptv.zig").renderContent(),
         .History => renderHistoryContent(),
         .RSS => rss.renderContent(),
         .Jellyfin => jellyfin_ui.renderContent(),

--- a/src/ui/shell.zig
+++ b/src/ui/shell.zig
@@ -551,7 +551,7 @@ fn renderPage(r: Route) !void {
         .search => drawer.renderTabContent(.Search),
         .home => @import("home.zig").render(), // personal hub: metrics + lists
         .browse => {
-            subTabs(&.{ .TMDB, .YouTube, .Anime, .Podcasts, .Radio, .Comics, .Web, .RSS, .Jellyfin, .Plex, .Audiobooks, .Opds, .Novels, .Vndb, .Drama }, &state.app.browse_source, 100);
+            subTabs(&.{ .TMDB, .YouTube, .Iptv, .Anime, .Podcasts, .Radio, .Comics, .Web, .RSS, .Jellyfin, .Plex, .Audiobooks, .Opds, .Novels, .Vndb, .Drama }, &state.app.browse_source, 100);
             drawer.renderTabContent(state.app.browse_source);
         },
         .watching => @import("../services/tv_library.zig").renderContent(),
@@ -580,6 +580,7 @@ fn tabLabel(t: state.DrawerTab) []const u8 {
         .Drama => "Asian Drama",
         .Podcasts => "Podcasts",
         .Radio => "Radio",
+        .Iptv => "Live TV",
         .History => "History",
         .RSS => "RSS",
         .Jellyfin => "Jellyfin",
@@ -610,6 +611,7 @@ pub fn iconForTab(t: state.DrawerTab) []const u8 {
         .Drama => icons.tvg.lucide.@"clapperboard",
         .Podcasts => icons.tvg.lucide.podcast,
         .Radio => icons.tvg.lucide.radio,
+        .Iptv => icons.tvg.lucide.@"monitor-play",
         .History => icons.tvg.lucide.history,
         .RSS => icons.tvg.lucide.rss,
         .Jellyfin => icons.tvg.lucide.server,

--- a/tests/features/test_browse_rail_groups.py
+++ b/tests/features/test_browse_rail_groups.py
@@ -14,7 +14,7 @@ import re
 
 # Every source tab that must live inside exactly one rail group.
 SOURCE_TABS = [
-    "TMDB", "Drama", "Jellyfin", "Plex", "YouTube", "Anime", "Comics",
+    "TMDB", "Drama", "Jellyfin", "Plex", "YouTube", "Iptv", "Anime", "Comics",
     "Novels", "Vndb", "Opds", "Podcasts", "Radio", "Audiobooks", "Web", "RSS",
 ]
 

--- a/tests/features/test_iptv.py
+++ b/tests/features/test_iptv.py
@@ -1,0 +1,101 @@
+"""Video — Live TV / IPTV (iptv-org) tab tests.
+
+Structural VIDEO twin of the Radio tab: keyless channel discovery via the
+iptv-org public directory (streams.json), m3u8/HLS streams handed straight to
+mpv. Opt-in via the source_config-gated "iptv-org" plugin, NSFW-filtered.
+
+Verify the full wiring: the tested pure module is registered + routed
+(tested logic == shipped logic), the service has the source_config gate +
+NSFW check + renderContent/playChannel, the DrawerTab enum/nav/render/rail are
+all wired, and the bundled manifest carries the iptv-org entry.
+
+See tests/features/harness.py for the shared @test decorator."""
+from .harness import *  # noqa: F401,F403
+
+import json
+import os
+
+
+@test("Live TV (IPTV) tab", "Video")
+def test_iptv_tab():
+    svc = _src("src/services/iptv.zig")
+    pure = _src("src/services/iptv_pure.zig")
+    st = _src("src/core/state.zig")
+    shell = _src("src/ui/shell.zig")
+    drawer = _src("src/ui/drawer.zig")
+    build = _src("build.zig")
+
+    checks = {
+        # ── Pure module: URL builder, m3u8/NSFW/accept decisions, parser ──
+        "pure module present": bool(pure),
+        "pure IptvChannel record": "pub const IptvChannel = struct" in pure,
+        "pure streams-url builder": "pub fn buildStreamsUrl" in pure,
+        "pure m3u8 recognizer": "pub fn isM3u8" in pure,
+        "pure NSFW gate": "pub fn isNsfw" in pure,
+        "pure accept decision": "pub fn acceptEntry" in pure,
+        "pure streams parser": "pub fn parseStreams" in pure,
+        # Accept gate is CALLED from the parser (drop unplayable/NSFW at parse time).
+        "accept routed in parseStreams": "acceptEntry(" in pure,
+
+        # ── Service: gate + async worker + thread-safety + play path ──
+        # Production routes through the pure fns (tested logic == shipped logic).
+        "service routes through pure": all(
+            f"pure.{fn}(" in svc
+            for fn in ("buildStreamsUrl", "parseStreams", "isM3u8")
+        ),
+        # Opt-in gate via source_config (plugin id "iptv-org").
+        "source_config gate": 'source_config.get("iptv-org", "base")' in svc,
+        "inert when uninstalled": "orelse return null" in svc,
+        # NSFW gating keyed on the app filter flag (inverse → nsfw_allowed).
+        "nsfw filter check": "nsfw_filter_enabled" in svc,
+        # iptv-org streams.json endpoint.
+        "streams.json endpoint": "streams.json" in svc or "streams.json" in pure,
+        # Discovery + search + play.
+        "popular one-shot": "pub fn loadPopularOnce" in svc,
+        "search entry": "pub fn searchIptv" in svc,
+        "infinite scroll": "pub fn loadMore" in svc,
+        "play hands url to mpv": "pub fn playChannel" in svc and "loadContentDirectMeta(" in svc,
+        "render entry": "pub fn renderContent" in svc,
+        # Thread discipline (mirrors radio.zig).
+        "atomic loading flag": "is_loading.store" in svc,
+        "publishes under mutex": "parse_mutex.lock()" in svc,
+        "generation guard": "search_gen" in svc,
+        # curl only — std.http SEGVs on some ISP TLS resets (see comics.zig).
+        "curl not std.http": "std.http.Client" not in svc and '"curl"' in svc,
+
+        # ── Enum → state → nav → render dispatch → rail/shell ──
+        # Assert MEMBERSHIP, not position (concurrent tab additions).
+        "enum variant present": "Iptv" in st and "pub const DrawerTab" in st,
+        "state struct": "iptv: struct {" in st,
+        "results buffer (capped)": "]iptv_pure.IptvChannel" in st,
+        "nav host page": ".Iptv => {" in st and "app.browse_source = .Iptv;" in st,
+        "render dispatch": '.Iptv => @import("../services/iptv.zig").renderContent()' in drawer,
+        "grouped under video": ".YouTube, .Iptv => .video" in drawer,
+        "rail nav entry": "renderRailTab(.Iptv" in drawer,
+        "shell label": '.Iptv => "Live TV"' in shell,
+        "shell icon (exists in pack)": '.Iptv => icons.tvg.lucide.@"monitor-play"' in shell,
+        "browse subtab": ".Iptv" in shell and "subTabs(&.{" in shell,
+
+        # ── Pure module registered in the `zig build test` step ──
+        "test registered": 'b.path("src/services/iptv_pure.zig")' in build,
+    }
+
+    # ── Bundled manifest carries the iptv-org plugin entry ──
+    mpath = os.path.join(PROJECT_DIR, "plugins-manifest.json")
+    manifest_ok = False
+    try:
+        with open(mpath) as f:
+            man = json.load(f)
+        for p in man.get("plugins", []):
+            if p.get("id") == "iptv-org" and p.get("type") == "iptv" \
+                    and "iptv-org.github.io" in p.get("endpoints", {}).get("base", ""):
+                manifest_ok = True
+                break
+    except Exception:
+        manifest_ok = False
+    checks["manifest iptv-org entry"] = manifest_ok
+
+    missing = [k for k, ok in checks.items() if not ok]
+    if not missing:
+        return "pass", "IPTV wired: pure(url/m3u8/nsfw/parse) -> gated fetch -> enum/nav/rail; manifest present"
+    return "fail", "IPTV wiring incomplete: " + ", ".join(missing)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -59,6 +59,7 @@ from features import (  # noqa: F401
     test_plugins_logs_ui,
     test_dpi_bypass,
     test_browse_rail_groups,
+    test_iptv,
 )
 
 if __name__ == "__main__":


### PR DESCRIPTION
Part 2 of the Browse work: an opt-in **IPTV / Live TV** tab — the video twin of Radio. It fetches the [iptv-org](https://iptv-org.github.io) public directory, NSFW-filters, and plays **m3u8/HLS** channels straight through mpv. It lives in the Browse rail's new **Video** group (added in #17).

## What
- **`services/iptv.zig`** — `source_config`-gated behind the `iptv-org` plugin (public API as the default base once installed); detached fetch worker guarded by `search_gen` + `parse_mutex`; SWR disk cache; `loadPopularOnce` / search / `loadMore` (progressive reveal, no refetch) / `playChannel` / `renderContent`. Mirrors `radio.zig`'s threading + caching exactly.
- **`services/iptv_pure.zig`** — tested pure logic (`buildStreamsUrl`, `isM3u8`, `isNsfw`, `acceptEntry`, bounds-safe `parseStreams`); production routes through it (11 unit tests).
- **`state.zig`** — `.Iptv` tab + a `[300]IptvChannel` result block.
- **`drawer.zig` / `shell.zig`** — grouped under **Video**, "Live TV" label, tv icon.
- **`plugins-manifest.json`** — bundled `iptv-org` entry (repo entry: [opal-plugins #3](https://github.com/debpalash/opal-plugins/pull/3)).

## Gate (verified independently)
`zig build` ✅ · `zig build test` ✅ (11 iptv_pure tests) · feature suite **214/0** (no-emoji + Live TV + rail-groups all green) · live `streams.json` confirmed to yield the exact `.m3u8` URLs the parser consumes.

## ⚠️ Known v1 limitation — NSFW filtering
`streams.json` carries **no `is_nsfw` flag and no category** (those live in the separate ~10 MB `channels.json`, not fetched in v1). So the NSFW gate keys on adult **tokens in the title/url** (`xxx`, `porn`, `hentai`, …), tuned against false positives like "Adult Swim" (regression-tested). This catches the obvious cases but is **less precise than a channel-id/category join** — an `xxx`-category channel with an innocuous title could slip through. Strengthening it (fetch `channels.json` or the `categories/xxx.m3u` exclusion list) is a clean follow-up. Also: `url` buffer is 512 bytes (rare very-long stream URLs could truncate); channel cap 300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)