### PR TITLE
feat(keys): ship default TMDB/OMDb keys — Movies/TV work out of the box (v0.6.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,16 @@
 # Opal Environment Variables
-# Copy this to .env and fill in your values
+# Copy this to .env and fill in your values.
+#
+# These keys are OPTIONAL for end users of a release build: Opal can ship with
+# working defaults baked in at build time (see build.zig / embeddedKey). This
+# file lets you (a) run from source with your own keys, or (b) provide the keys
+# a release build embeds — set them here (or as build-time env vars) before
+# `zig build`. A value set here always overrides the embedded default at runtime.
 
-# TMDB API Bearer Token (get from https://www.themoviedb.org/settings/api)
+# TMDB API Bearer Token — posters, seasons, trending, search.
+# Get from https://www.themoviedb.org/settings/api (use the v4 "API Read Access Token").
 TMDB_API_TOKEN=your_bearer_token_here
+
+# OMDb API key — real IMDb / Rotten Tomatoes / Metacritic scores on the detail view.
+# Free (1,000/day) from https://www.omdbapi.com/apikey.aspx. Optional.
+OMDB_API_KEY=your_omdb_key_here

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,12 @@ jobs:
           brew update
           brew install mpv sqlite onnxruntime sdl2 libtorrent-rasterbar create-dmg
       - name: Build .app bundle (ReleaseFast)
+        # Bake the default TMDB/OMDb keys into the release binary so end users
+        # work out of the box (build.zig reads these env vars). Absent secrets
+        # resolve to "" — the build just falls back to bring-your-own-key.
+        env:
+          OPAL_TMDB_TOKEN: ${{ secrets.TMDB_API_TOKEN }}
+          OPAL_OMDB_KEY: ${{ secrets.OMDB_API_KEY }}
         run: ./scripts/build-app.sh
       - name: Package
         run: |
@@ -83,6 +89,10 @@ jobs:
           sudo cp -r onnxruntime-linux-x64-${ORT_VER}/lib/*     /usr/local/lib/
           sudo ldconfig
       - name: Build (ReleaseSafe)
+        # Bake the default TMDB/OMDb keys into the release binary (see build.zig).
+        env:
+          OPAL_TMDB_TOKEN: ${{ secrets.TMDB_API_TOKEN }}
+          OPAL_OMDB_KEY: ${{ secrets.OMDB_API_KEY }}
         run: zig build -Doptimize=ReleaseSafe -fsys=sdl2
       - name: Package binary tarball
         run: |
@@ -243,6 +253,10 @@ jobs:
           echo "ONNXRUNTIME_DIR=$(pwd -W)/onnxruntime-win-x64-${ORT_VER}" >> "$GITHUB_ENV"
 
       - name: Build (ReleaseSafe)
+        # Bake the default TMDB/OMDb keys into the release binary (see build.zig).
+        env:
+          OPAL_TMDB_TOKEN: ${{ secrets.TMDB_API_TOKEN }}
+          OPAL_OMDB_KEY: ${{ secrets.OMDB_API_KEY }}
         run: zig build -Doptimize=ReleaseSafe
 
       - name: Stage portable payload (exe + wrapper + DLL closure)

--- a/build.zig
+++ b/build.zig
@@ -10,6 +10,18 @@ pub fn build(b: *std.Build) void {
     const build_options = b.addOptions();
     build_options.addOption(bool, "headless", headless);
 
+    // Default API keys compiled into the binary so a fresh install works out of
+    // the box — end users of a release build don't have to register their own.
+    // Resolved at build time from env vars (release CI injects repo secrets),
+    // falling back to a repo-root `.env` (gitignored) for local release builds.
+    // Empty when unset, which just restores bring-your-own-key behavior. A
+    // runtime env var / .env / Settings entry always OVERRIDES the embedded
+    // value (see state.loadTmdbTokenFromEnv). NB: an embedded key is extractable
+    // from the shipped binary — only bake in free, rate-limited keys (a TMDB
+    // read token, an OMDb free key), never anything sensitive.
+    build_options.addOption([]const u8, "tmdb_default_token", embeddedKey(b, &.{ "OPAL_TMDB_TOKEN", "TMDB_API_TOKEN" }));
+    build_options.addOption([]const u8, "omdb_default_key", embeddedKey(b, &.{ "OPAL_OMDB_KEY", "OMDB_API_KEY" }));
+
     const exe = b.addExecutable(.{
         .name = "opal",
         .root_module = b.createModule(.{
@@ -1457,4 +1469,44 @@ pub fn build(b: *std.Build) void {
         }),
     });
     test_step.dependOn(&b.addRunArtifact(test_music_plex_pure).step);
+}
+
+/// Resolve a build-time default API key: the first matching build environment
+/// variable wins; otherwise fall back to a `NAME=value` line in the repo-root
+/// `.env` (gitignored). Returns "" when nothing is found, which the app treats
+/// as "no embedded default". Never bakes a value into the repo — the source is
+/// the build environment or an untracked .env.
+fn embeddedKey(b: *std.Build, names: []const []const u8) []const u8 {
+    for (names) |name| {
+        if (b.graph.environ_map.get(name)) |v| {
+            if (v.len > 0) return b.dupe(v);
+        }
+    }
+    // .env is optional; a missing file / read error just means "no default".
+    const body = b.build_root.handle.readFileAlloc(b.graph.io, ".env", b.allocator, .limited(64 * 1024)) catch return "";
+    for (names) |name| {
+        if (envFileValue(body, name)) |v| {
+            if (v.len > 0) return b.dupe(v);
+        }
+    }
+    return "";
+}
+
+/// Minimal `.env` lookup for build time: find a `NAME=value` line, skipping
+/// blank and `#`-comment lines and stripping one layer of surrounding quotes.
+/// Mirrors src/core/env.zig's runtime parser closely enough for key extraction.
+fn envFileValue(body: []const u8, name: []const u8) ?[]const u8 {
+    var it = std.mem.splitScalar(u8, body, '\n');
+    while (it.next()) |raw| {
+        const line = std.mem.trim(u8, raw, " \t\r");
+        if (line.len == 0 or line[0] == '#') continue;
+        const eq = std.mem.indexOfScalar(u8, line, '=') orelse continue;
+        if (!std.mem.eql(u8, std.mem.trim(u8, line[0..eq], " \t"), name)) continue;
+        var val = std.mem.trim(u8, line[eq + 1 ..], " \t");
+        if (val.len >= 2 and (val[0] == '"' or val[0] == '\'') and val[val.len - 1] == val[0]) {
+            val = val[1 .. val.len - 1];
+        }
+        return val;
+    }
+    return null;
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .opal,
-    .version = "0.5.0",
+    .version = "0.6.0",
     .dependencies = .{
         .dvui = .{
             .url = "git+https://github.com/debpalash/dvui#c2424c15cbfacfe24d66fda4963055eb4c9ee200",

--- a/src/core/config.zig
+++ b/src/core/config.zig
@@ -63,9 +63,12 @@ pub fn save() void {
     setKey("dpi_bypass_mode", if (state.app.dpi_bypass_mode_len > 0) state.app.dpi_bypass_mode[0..state.app.dpi_bypass_mode_len] else "sni");
     setKey("ytdl_format_idx", fmtInt(&fb, state.app.ytdl_format_idx));
     setKey("drawer_width_px", fmtFloat(&fb, state.app.drawer_width_px));
-    setKey("tmdb_api_key", state.app.tmdb.api_key[0..state.app.tmdb.api_key_len]);
+    // Persist only USER keys, never the build-time embedded default: writing the
+    // default would pin it in the user's DB and defeat key rotation, and would
+    // make a fresh install look "already onboarded". Empty string clears the row.
+    setKey("tmdb_api_key", if (state.app.tmdb.api_key_is_default) "" else state.app.tmdb.api_key[0..state.app.tmdb.api_key_len]);
     setKey("opensub_api_key", state.app.opensub_api_key[0..state.app.opensub_api_key_len]);
-    setKey("omdb_api_key", state.app.omdb_api_key[0..state.app.omdb_api_key_len]);
+    setKey("omdb_api_key", if (state.app.omdb_api_key_is_default) "" else state.app.omdb_api_key[0..state.app.omdb_api_key_len]);
     setKey("subdl_api_key", state.app.subdl_api_key[0..state.app.subdl_api_key_len]);
     setKey("sponsorblock_enabled", if (state.app.sponsorblock_enabled) "1" else "0");
     setKey("anime_skip_enabled", if (state.app.anime_skip_enabled) "1" else "0");
@@ -218,8 +221,11 @@ pub fn load() void {
 
     // Grandfather pre-wizard installs: a config that already carries a TMDB
     // key or has source plugins installed predates onboarding — don't nag.
+    // The build-time embedded default key does NOT count (every fresh install
+    // has it) — only a real user-supplied key marks a pre-wizard install.
     if (!state.app.onboarded and
-        (state.app.tmdb.api_key_len > 0 or @import("source_config.zig").anyInstalled()))
+        ((state.app.tmdb.api_key_len > 0 and !state.app.tmdb.api_key_is_default) or
+            @import("source_config.zig").anyInstalled()))
     {
         state.app.onboarded = true;
     }
@@ -348,8 +354,10 @@ fn applyConfig(key: []const u8, val: []const u8) void {
         state.app.drawer_width_px = std.fmt.parseFloat(f32, val) catch 480.0;
     } else if (std.mem.eql(u8, key, "tmdb_api_key")) {
         if (val.len > 0 and val.len <= 256) {
+            // A saved key is a real user key — override any embedded default.
             @memcpy(state.app.tmdb.api_key[0..val.len], val);
             state.app.tmdb.api_key_len = val.len;
+            state.app.tmdb.api_key_is_default = false;
         }
     } else if (std.mem.eql(u8, key, "opensub_api_key")) {
         if (val.len > 0 and val.len <= 128) {
@@ -360,6 +368,7 @@ fn applyConfig(key: []const u8, val: []const u8) void {
         if (val.len > 0 and val.len <= 128) {
             @memcpy(state.app.omdb_api_key[0..val.len], val);
             state.app.omdb_api_key_len = val.len;
+            state.app.omdb_api_key_is_default = false;
         }
     } else if (std.mem.eql(u8, key, "subdl_api_key")) {
         if (val.len > 0 and val.len <= 128) {

--- a/src/core/state.zig
+++ b/src/core/state.zig
@@ -677,6 +677,10 @@ pub const AppState = struct {
         thread: ?std.Thread = null,
         api_key: [256]u8 = std.mem.zeroes([256]u8),
         api_key_len: usize = 0,
+        // True when api_key holds the build-time embedded default rather than a
+        // user-supplied key. Kept out of the saved config (so key rotation
+        // reaches everyone) and out of the "already onboarded" heuristic.
+        api_key_is_default: bool = false,
         loaded_once: bool = false,
         // Gallery card target width (px) — user-cyclable compact/normal/large/xl.
         card_w: f32 = 124,
@@ -707,10 +711,15 @@ pub const AppState = struct {
     opensub_api_key_len: usize = 0,
 
     // ── OMDb (omdbapi.com) ratings enrichment ──
-    // User-supplied free key (omdbapi.com, 1k/day). Empty → the OMDb worker is
-    // fully inert (no fetch). Persisted like tmdb/opensub keys; see config.zig.
+    // Free key (omdbapi.com, 1k/day) for real IMDb / RT / Metacritic scores.
+    // May be user-supplied or the build-time embedded default; empty → the OMDb
+    // worker is fully inert (no fetch). User keys persist like tmdb/opensub keys;
+    // the embedded default does not (see config.zig / omdb_api_key_is_default).
     omdb_api_key: [128]u8 = std.mem.zeroes([128]u8),
     omdb_api_key_len: usize = 0,
+    // True when omdb_api_key holds the build-time embedded default (mirrors
+    // tmdb.api_key_is_default): kept out of the saved config.
+    omdb_api_key_is_default: bool = false,
 
     // ── Subdl (api.subdl.com) subtitle provider ──
     // User-supplied FREE per-user key (subdl.com → panel → API). Empty → the
@@ -1284,23 +1293,69 @@ pub var players_mutex: @import("sync.zig").Mutex = .{};
 // Utility Functions
 // ══════════════════════════════════════════════════════════
 
-/// Load TMDB token from the environment ($OPAL_TMDB_TOKEN, $TMDB_API_TOKEN,
-/// or legacy $ZIGZAG_TMDB_TOKEN), or fall back to .env file.
+/// Copy a user-supplied TMDB token into app state (clears the "embedded
+/// default" flag so it persists and counts as onboarding).
+pub fn setTmdbKey(token: []const u8) void {
+    const len = @min(token.len, app.tmdb.api_key.len);
+    @memcpy(app.tmdb.api_key[0..len], token[0..len]);
+    app.tmdb.api_key_len = len;
+    app.tmdb.api_key_is_default = false;
+}
+
+/// Copy a user-supplied OMDb key into app state (clears the default flag).
+pub fn setOmdbKey(key: []const u8) void {
+    const len = @min(key.len, app.omdb_api_key.len);
+    @memcpy(app.omdb_api_key[0..len], key[0..len]);
+    app.omdb_api_key_len = len;
+    app.omdb_api_key_is_default = false;
+}
+
+/// Load the TMDB + OMDb keys at startup. Precedence, highest first:
+///   1. environment vars ($OPAL_TMDB_TOKEN / $TMDB_API_TOKEN / legacy; and
+///      $OPAL_OMDB_KEY / $OMDB_API_KEY),
+///   2. a `.env` file (cwd, then the config dir),
+///   3. the keys embedded at build time (build_options) — so a fresh install
+///      works with no setup. A later config.load() (a saved Settings key) still
+///      overrides everything here.
 pub fn loadTmdbTokenFromEnv() void {
-    // 1. Try env vars first (new name, generic name, legacy name).
-    const env_names = [_][*:0]const u8{ "OPAL_TMDB_TOKEN", "TMDB_API_TOKEN", "ZIGZAG_TMDB_TOKEN" };
-    for (env_names) |name| {
+    // 1. Process env vars first.
+    const tmdb_env = [_][*:0]const u8{ "OPAL_TMDB_TOKEN", "TMDB_API_TOKEN", "ZIGZAG_TMDB_TOKEN" };
+    for (tmdb_env) |name| {
         if (if (std.c.getenv(name)) |raw| std.mem.span(raw) else null) |token| {
             if (token.len > 0) {
-                const len = @min(token.len, app.tmdb.api_key.len);
-                @memcpy(app.tmdb.api_key[0..len], token[0..len]);
-                app.tmdb.api_key_len = len;
-                return;
+                setTmdbKey(token);
+                break;
             }
         }
     }
-    // 2. Fall back to .env file in cwd
+    const omdb_env = [_][*:0]const u8{ "OPAL_OMDB_KEY", "OMDB_API_KEY" };
+    for (omdb_env) |name| {
+        if (if (std.c.getenv(name)) |raw| std.mem.span(raw) else null) |key| {
+            if (key.len > 0) {
+                setOmdbKey(key);
+                break;
+            }
+        }
+    }
+
+    // 2. Fall back to .env (only fills keys still unset).
     loadTmdbFromDotEnv();
+
+    // 3. Fall back to the build-time embedded defaults. Marked is_default so
+    //    they are neither persisted nor treated as "the user brought a key".
+    const build_options = @import("build_options");
+    if (app.tmdb.api_key_len == 0 and build_options.tmdb_default_token.len > 0) {
+        const len = @min(build_options.tmdb_default_token.len, app.tmdb.api_key.len);
+        @memcpy(app.tmdb.api_key[0..len], build_options.tmdb_default_token[0..len]);
+        app.tmdb.api_key_len = len;
+        app.tmdb.api_key_is_default = true;
+    }
+    if (app.omdb_api_key_len == 0 and build_options.omdb_default_key.len > 0) {
+        const len = @min(build_options.omdb_default_key.len, app.omdb_api_key.len);
+        @memcpy(app.omdb_api_key[0..len], build_options.omdb_default_key[0..len]);
+        app.omdb_api_key_len = len;
+        app.omdb_api_key_is_default = true;
+    }
 }
 
 fn readFileAll(dir_path: []const u8, name: []const u8, buf: []u8) ?[]const u8 {
@@ -1335,9 +1390,18 @@ fn loadTmdbFromDotEnv() void {
         const keys = [_][]const u8{ "TMDB_API_TOKEN=", "OPAL_TMDB_TOKEN=", "ZIGZAG_TMDB_TOKEN=" };
         for (keys) |key| {
             if (env.findValue(content, key)) |token| {
-                const len = @min(token.len, app.tmdb.api_key.len);
-                @memcpy(app.tmdb.api_key[0..len], token[0..len]);
-                app.tmdb.api_key_len = len;
+                setTmdbKey(token);
+                break;
+            }
+        }
+    }
+
+    // OMDb key (IMDb / RT / Metacritic ratings) — same pattern
+    if (app.omdb_api_key_len == 0) {
+        const keys = [_][]const u8{ "OMDB_API_KEY=", "OPAL_OMDB_KEY=" };
+        for (keys) |key| {
+            if (env.findValue(content, key)) |token| {
+                setOmdbKey(token);
                 break;
             }
         }

--- a/src/services/remote.zig
+++ b/src/services/remote.zig
@@ -626,10 +626,8 @@ fn handleApi(stream: std.Io.net.Stream, api_path: []const u8, query: []const u8)
         if (getQueryParam(query, "key")) |raw| {
             var dec: [400]u8 = undefined;
             const key = urlDecode(raw, &dec) orelse raw;
-            const n = @min(key.len, state.app.tmdb.api_key.len);
-            if (n > 0) {
-                @memcpy(state.app.tmdb.api_key[0..n], key[0..n]);
-                state.app.tmdb.api_key_len = n;
+            if (key.len > 0) {
+                state.setTmdbKey(key);
                 state.markConfigDirty();
             }
         }

--- a/src/services/updater.zig
+++ b/src/services/updater.zig
@@ -13,7 +13,7 @@ const alloc = @import("../core/alloc.zig").allocator;
 
 /// Current app version. Kept in sync with build.zig.zon + Info.plist
 /// (scripts/build-app.sh derives CFBundleShortVersionString from the zon).
-pub const APP_VERSION: []const u8 = "0.5.0";
+pub const APP_VERSION: []const u8 = "0.6.0";
 
 const RELEASE_API = "https://api.github.com/repos/debpalash/Opal/releases/latest";
 

--- a/src/ui/onboarding.zig
+++ b/src/ui/onboarding.zig
@@ -188,9 +188,7 @@ fn setupPage() void {
             if (accentButton(220, "Save") or entered) {
                 const klen = std.mem.indexOfScalar(u8, &tmdb_key_buf, 0) orelse 0;
                 if (klen > 0) {
-                    const n = @min(klen, state.app.tmdb.api_key.len);
-                    @memcpy(state.app.tmdb.api_key[0..n], tmdb_key_buf[0..n]);
-                    state.app.tmdb.api_key_len = n;
+                    state.setTmdbKey(tmdb_key_buf[0..klen]);
                     state.markConfigDirty();
                     state.showToast("TMDB key saved");
                 }

--- a/src/ui/settings.zig
+++ b/src/ui/settings.zig
@@ -1207,9 +1207,18 @@ fn renderGeneralTab() void {
         });
         const tmdb_changed = te.text_changed;
         te.deinit();
+        const tmdb_was_default = state.app.tmdb.api_key_is_default;
         state.app.tmdb.api_key_len = std.mem.indexOfScalar(u8, &state.app.tmdb.api_key, 0) orelse 0;
-        if (tmdb_changed) state.markConfigDirty();
-        _ = dvui.label(@src(), "Free key from themoviedb.org/settings/api", .{}, .{
+        if (tmdb_changed) {
+            // Any edit turns the field into a real user key (persisted, overrides
+            // the built-in default).
+            state.app.tmdb.api_key_is_default = false;
+            state.markConfigDirty();
+        }
+        _ = dvui.label(@src(), "{s}", .{if (tmdb_was_default and !tmdb_changed)
+            "Using Opal's built-in key — paste your own to override."
+        else
+            "Free key from themoviedb.org/settings/api"}, .{
             .id_extra = 143,
             .color_text = theme.colors.text_tertiary,
             .margin = .{ .x = 0, .y = 4, .w = 0, .h = 0 },
@@ -1223,6 +1232,7 @@ fn renderGeneralTab() void {
     settingRow("API Key", 150, @src());
     {
         const has_omdb = state.app.omdb_api_key_len > 0;
+        const omdb_was_default = state.app.omdb_api_key_is_default;
         var te = dvui.textEntry(@src(), .{ .text = .{ .buffer = &state.app.omdb_api_key }, .placeholder = "Optional — paste free key from omdbapi.com", .password_char = "•" }, .{
             .id_extra = 152,
             .expand = .horizontal,
@@ -1236,8 +1246,13 @@ fn renderGeneralTab() void {
         const omdb_changed = te.text_changed;
         te.deinit();
         state.app.omdb_api_key_len = std.mem.indexOfScalar(u8, &state.app.omdb_api_key, 0) orelse 0;
-        if (omdb_changed) state.markConfigDirty();
-        _ = dvui.label(@src(), "{s}", .{if (has_omdb)
+        if (omdb_changed) {
+            state.app.omdb_api_key_is_default = false;
+            state.markConfigDirty();
+        }
+        _ = dvui.label(@src(), "{s}", .{if (omdb_was_default and !omdb_changed)
+            "Using Opal's built-in key — paste your own to override."
+        else if (has_omdb)
             "Key set — IMDb / RT / Metacritic scores show on movie & show pages."
         else
             "Free key (1,000/day) from omdbapi.com/apikey.aspx — leave blank to disable."}, .{


### PR DESCRIPTION
## What
Bakes default TMDB (and OMDb) API keys into the binary at build time so a fresh install shows Movies/TV, ratings, etc. **without the user registering their own key**. Users can still override via env / `.env` / Settings.

## How
- `build.zig`: `embeddedKey()` reads `OPAL_TMDB_TOKEN`/`TMDB_API_TOKEN` and `OPAL_OMDB_KEY`/`OMDB_API_KEY` at build time (env var, then repo-root `.env`) → `build_options.{tmdb_default_token,omdb_default_key}`. Empty when unset (old bring-your-own behavior).
- Runtime precedence: **saved Settings key > `$OPAL_*`/`.env` > embedded default**. New `is_default` flags keep the embedded key out of the saved DB and out of the "already onboarded" heuristic.
- `release.yml`: injects the keys into all 3 platform builds from repo secrets `TMDB_API_TOKEN` / `OMDB_API_KEY`.
- Version bump → **0.6.0**.

## Verified (Windows 11)
Clean-config install with **no user key** loads TMDB Trending + full Browse grid, Radio, Podcasts, and JioSaavn music. `zig build` + `zig build test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)