### PR TITLE
chore(git): ignore the Claude Code skills tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,11 @@ zig-pkg/
 # === AI assistant config ===
 CLAUDE.md
 .antigravitycli/
+# Claude Code skills tooling: .agents/skills is the installed-skill cache and
+# skills-lock.json pins their hashes. Both are regenerated per machine and turn
+# up as untracked noise in every `git status` on a checkout that uses them.
+.agents/
+skills-lock.json
 
 # === IDE config (machine-specific) ===
 zls.json


### PR DESCRIPTION
`.agents/skills` (the installed-skill cache) and `skills-lock.json` (their pinned hashes) are regenerated per machine, so on any checkout that uses Claude Code they show up as two untracked entries in every `git status` — noise that is never meant to be committed.

They go next to `CLAUDE.md` and `.antigravitycli/`, which `.gitignore` already carries for exactly the same reason.

Verified with `git check-ignore -v`: both paths now resolve to the new rules, and `git status` is clean.