### PR TITLE
feat(windows): sign the whole release payload, not just opal.exe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,6 +202,14 @@ jobs:
   windows-x86_64:
     runs-on: windows-2022
     continue-on-error: true
+    permissions:
+      contents: read
+      id-token: write # OIDC token for azure/login, used by the signing steps
+    env:
+      # Signing is opt-in: with no Azure secrets configured the signing steps
+      # skip and the job still produces (unsigned) artifacts, so forks and
+      # secret-less builds are unaffected.
+      SIGNING_ENABLED: ${{ secrets.AZURE_CLIENT_ID != '' }}
     defaults:
       run:
         # Build steps run inside the MSYS2 environment: zig build shells out
@@ -446,6 +454,82 @@ jobs:
           Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
           exit 0
 
+      # ── Code signing ─────────────────────────────────────────────────────
+      # Smart App Control is on by default for clean Windows 11 installs and
+      # has no "run anyway" — unlike SmartScreen, the user cannot click past
+      # it. Its decision order (per Microsoft's own SAC FAQ) is: ask the cloud;
+      # if the cloud has no confident verdict — which is every new release from
+      # a small publisher — fall back to the signature, and treat an unsigned
+      # file as untrusted. There is no allowlist, no per-app review, and no way
+      # to request an exception, so signing is the only lever that exists.
+      #
+      # SAC validates EVERY module it loads, not just the launched exe: the
+      # ~50 MSYS2 DLLs in the closure and the MSI itself all have to be signed
+      # too, which is why this signs the whole staged payload rather than
+      # opal.exe alone. Signing must also land BEFORE the zip and before heat
+      # harvests staging/, so both artifacts carry signed payloads.
+      #
+      # Trusted Signing issues RSA certificates. Do not switch to ECC: the
+      # Code Integrity path SAC uses does not accept ECC signatures.
+      - name: Set aside already-signed binaries
+        if: env.SIGNING_ENABLED == 'true'
+        shell: pwsh
+        run: |
+          # onnxruntime and the VC++ runtime arrive signed by Microsoft, and
+          # those signatures already carry reputation. Re-signing REPLACES a
+          # signature rather than adding one, so swapping Microsoft's for ours
+          # would be a downgrade — they sit the signing step out.
+          New-Item -ItemType Directory -Force -Path sign-inbox | Out-Null
+          $queued = 0
+          Get-ChildItem staging -File |
+            Where-Object { $_.Extension -in '.exe', '.dll' } |
+            ForEach-Object {
+              if (-not (Get-AuthenticodeSignature $_.FullName).SignerCertificate) {
+                Move-Item $_.FullName (Join-Path 'sign-inbox' $_.Name)
+                $queued++
+              }
+            }
+          Write-Host "$queued unsigned binaries queued for signing"
+
+      - name: Azure login (OIDC)
+        if: env.SIGNING_ENABLED == 'true'
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Sign the payload (Azure Artifact Signing)
+        if: env.SIGNING_ENABLED == 'true'
+        uses: azure/artifact-signing-action@v2
+        with:
+          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ secrets.AZURE_SIGNING_PROFILE }}
+          files-folder: ${{ github.workspace }}\sign-inbox
+          files-folder-filter: exe,dll
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Restore signed binaries and verify the closure
+        if: env.SIGNING_ENABLED == 'true'
+        shell: pwsh
+        run: |
+          Get-ChildItem sign-inbox -File | Move-Item -Destination staging
+          Remove-Item sign-inbox -Recurse -Force
+          # One unsigned straggler is all SAC needs to block the app, and it
+          # would surface as an unreproducible "works for me" bug report. Fail
+          # the build here instead of shipping it.
+          $unsigned = Get-ChildItem staging -File |
+            Where-Object { $_.Extension -in '.exe', '.dll' } |
+            Where-Object { -not (Get-AuthenticodeSignature $_.FullName).SignerCertificate }
+          if ($unsigned) {
+            Write-Host "::error::unsigned binaries remain in the payload: $($unsigned.Name -join ', ')"
+            exit 1
+          }
+          Write-Host "every PE in staging/ is signed"
+
       - name: Package portable zip
         shell: pwsh
         run: Compress-Archive -Path staging\* -DestinationPath "opal-${env:VERSION}-windows-x86_64.zip"
@@ -479,6 +563,34 @@ jobs:
           & "$wix\light.exe" -nologo -sval opal.wixobj harvest.wixobj `
               -o "Opal-${env:VERSION}-windows-x86_64.msi"
           exit $LASTEXITCODE
+
+      # The installer is itself a module SAC evaluates, and it is the first
+      # thing a user runs — an unsigned MSI is blocked before any of the signed
+      # payload inside it is ever reached.
+      - name: Sign the MSI
+        if: env.SIGNING_ENABLED == 'true'
+        uses: azure/artifact-signing-action@v2
+        with:
+          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ secrets.AZURE_SIGNING_PROFILE }}
+          files-folder: ${{ github.workspace }}
+          files-folder-filter: msi
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Verify the MSI is signed
+        if: env.SIGNING_ENABLED == 'true'
+        shell: pwsh
+        run: |
+          $msi = Get-ChildItem "Opal-*-windows-x86_64.msi" | Select-Object -First 1
+          $sig = Get-AuthenticodeSignature $msi.FullName
+          if (-not $sig.SignerCertificate) {
+            Write-Host "::error::$($msi.Name) is unsigned"
+            exit 1
+          }
+          Write-Host "$($msi.Name) signed by $($sig.SignerCertificate.Subject)"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -460,7 +460,15 @@ actually works — and it's free.
       macos-arm64 release job (scripts/build-app.sh already honors them and
       handles signing before DMG creation). Result: no "could not verify"
       dialog, ever.
-- [ ] Windows: an OV/EV Authenticode certificate (or Azure Trusted Signing)
-      signs opal.exe + the .msi and retires SmartScreen's "unknown publisher"
-      interstitial. Until then reputation accrues per-file-hash, so each
-      release restarts it.
+- [~] Windows: the release job signs the entire staged closure + the .msi via
+      Azure Artifact Signing (formerly Trusted Signing), and hard-fails if any
+      PE in the payload is left unsigned. WIRED BUT DORMANT — it is gated on
+      `AZURE_CLIENT_ID`, so until that secret exists every release still ships
+      unsigned. See packaging/windows/README.md for the six secrets and the
+      identity validation needed to switch it on.
+      This matters more than the SmartScreen interstitial: Smart App Control
+      is default-on for clean Windows 11 installs and offers users NO way to
+      click past a block. It falls back to the signature whenever its cloud
+      has no confident verdict, which is the normal case for a new release —
+      and it checks every DLL and the MSI, not just opal.exe. Signing is the
+      only lever; there is no allowlist and no per-app review to appeal to.

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -7,4 +7,19 @@
 
 **DLL harvest** (see the `windows-x86_64` job in `.github/workflows/release.yml`): the job copies `opal.exe`, the torrent wrapper, `onnxruntime.dll` (+ the msvcp140/vcruntime140 runtime it needs) into `staging/`, then runs `ldd` over everything staged **to a fixpoint** — each pass copies every dependency under `$MINGW_PREFIX` (`/mingw64`) not yet staged, until a pass adds nothing (a single pass misses transitive deps like `libbrotlidec`/`libintl-8`; that's how v0.1.0 shipped broken). Unresolvable imports fail the job, and a non-MSYS2 `pwsh` step then launches `staging/opal.exe` and asserts it survives 10 s — the same DLL-search environment as a user's machine. The same `staging/` dir becomes both the portable zip and, via `heat.exe dir staging -cg OpalFiles`, the MSI's file fragment (`candle` + `light` link it against `opal.wxs`).
 
+**Code signing** (the `Sign the payload` / `Sign the MSI` steps in the `windows-x86_64` job). Smart App Control ships on by default on clean Windows 11 installs and, unlike SmartScreen, offers the user no way to click past a block. Microsoft's SAC FAQ describes the decision order: the cloud is asked first, and *when it has no confident verdict — the normal case for a new release from a small publisher — SAC falls back to the signature and treats an unsigned file as untrusted*. There is no allowlist, no per-app review, and no exception process, so signing is the only available lever. SAC also evaluates **every module it loads**, so the whole staged closure (~50 MSYS2 DLLs) and the MSI are signed, not just `opal.exe`; a single unsigned straggler is enough to trip it, which is why the job hard-fails if one survives.
+
+Signing is **opt-in**: with no `AZURE_CLIENT_ID` repo secret the steps skip and the job still produces unsigned artifacts, so forks are unaffected. To enable it, create an [Azure Artifact Signing](https://azure.microsoft.com/en-us/products/artifact-signing) account (formerly Trusted Signing; $9.99/mo Basic) — it requires identity validation, and individual developers are eligible in the US, Canada, EU and UK. Then set six repo secrets:
+
+| Secret | Example |
+| --- | --- |
+| `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` | the app registration federated to this repo via OIDC |
+| `AZURE_SIGNING_ENDPOINT` | `https://eus.codesigning.azure.net/` (region-specific) |
+| `AZURE_SIGNING_ACCOUNT` | signing account name |
+| `AZURE_SIGNING_PROFILE` | certificate profile name |
+
+The identity needs the **Trusted Signing Certificate Profile Signer** role. Keep the certificate RSA — the Code Integrity path SAC uses does not accept ECC signatures.
+
+Signing removes the SmartScreen interstitial and satisfies SAC's signature fallback, but it does not make a brand-new binary *reputable*: reputation accrues per publisher as installs accumulate, and it accrues across releases with a stable certificate rather than resetting per file hash as it does for unsigned builds.
+
 **Iterating locally on a Windows box**: install [MSYS2](https://www.msys2.org), open a *MINGW64* shell, `pacman -S unzip mingw-w64-x86_64-{gcc,SDL2,mpv,sqlite3,libtorrent-rasterbar,pkgconf}`, unpack `onnxruntime-win-x64-<ver>.zip` from github.com/microsoft/onnxruntime/releases and `export ONNXRUNTIME_DIR=<its root>`, put zig 0.16 on PATH, then `zig build -Doptimize=ReleaseSafe` and replay the workflow's staging/heat/candle/light steps verbatim (WiX 3.14 from wixtoolset.org if not preinstalled). Pin an onnxruntime whose DLL serves the `ORT_API_VERSION` in `ort/onnxruntime_c_api.h` (currently 24 → 1.24.x).


### PR DESCRIPTION
Every release so far has shipped unsigned. This wires Authenticode signing into the `windows-x86_64` release job.

## Why this is the only lever

Smart App Control is on by default on clean Windows 11 installs and, unlike SmartScreen, gives the user **no way to click past a block**. Per [Microsoft's SAC FAQ](https://support.microsoft.com/en-us/windows/smart-app-control-frequently-asked-questions-285ea03d-fa88-4d56-882e-6698afdb7003), the decision order is: ask the cloud first, and when it has no confident verdict — the normal case for a new release from a small publisher — fall back to the signature and treat an unsigned file as untrusted. Microsoft states plainly that there is **no way to bypass SAC for individual apps** and no per-app review to appeal to. Signing is the entire remedy.

## Why signing opal.exe alone would not have worked

SAC validates **every module it loads**, not just the launched executable. This release bundles ~50 unsigned MSYS2 DLLs (libmpv, libtorrent, boost, openssl, SDL2, the ffmpeg libs) plus the MSI, and all of them are evaluated.

So the job now:

- signs the **entire staged closure** before the zip is compressed and before `heat` harvests `staging/`, so both artifacts carry signed contents;
- signs the **MSI** after `light.exe` links it — it is the first thing a user runs, and an unsigned installer is blocked before any signed payload inside it is reached;
- **hard-fails if any PE survives unsigned.** One straggler is enough to trip SAC, and it would surface as an unreproducible "works for me" report.

Microsoft-signed files (onnxruntime, the VC++ runtime) are moved aside first. Re-signing *replaces* a signature rather than adding one, so overwriting theirs with ours would trade away reputation they already have.

## Dormant until secrets exist

Gated on `AZURE_CLIENT_ID`. With no secrets the steps skip and the job still produces unsigned artifacts, so forks and secret-less builds are unaffected. **Merging this changes nothing on its own** — enabling it needs an Azure Artifact Signing account (identity validation required; individual developers eligible in US/CA/EU/UK) and six repo secrets, documented in `packaging/windows/README.md`.

The certificate must stay RSA: the Code Integrity path SAC uses does not accept ECC signatures.

## What this does not do

Signing is necessary, not sufficient. It clears the signature fallback and retires the SmartScreen interstitial, but it does not make a brand-new binary *reputable* — reputation still accrues with installs. The gain is that it then accrues per publisher across releases with a stable certificate, instead of resetting per file hash on every tag as it does today.

Workflow YAML validated with a parser; step ordering confirmed (stage → smoke test → sign payload → zip → MSI → sign MSI → upload).