### PR TITLE
fix(ci): the two Packaging tests that have been red on main

### DIFF
--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -78,11 +78,27 @@ fi
 # changelog that silently omits commits is worse than an untidy one.
 log=$(git -C "$ROOT" log --no-merges --format='%h%x09%s' "$RANGE" 2>/dev/null || true)
 
+# Every type that gets a home of its own, either in a section above or in the
+# internal fold below. "Other" is defined as the complement of this set, so a
+# commit can only ever be listed once and can never fall through the gaps.
+KNOWN_TYPES='feat|fix|perf|revert|test|chore|refactor|docs|ci'
+
 # Scope handling stays in sed rather than awk: `match(str, re, arr)` is a gawk
 # extension and this script also runs on macOS's one-true-awk.
+select_types() {
+    # $1 = alternation of conventional types; $2 = "-v" to select the commits
+    # matching NONE of them (`grep .` first so an empty log cannot become one
+    # blank line that -v then happily "matches").
+    if [ "${2:-}" = "-v" ]; then
+        printf '%s\n' "$log" | grep . | grep -Ev "$(printf '\t')($1)(\(|!?:)" || true
+    else
+        printf '%s\n' "$log" | grep -E "$(printf '\t')($1)(\(|!?:)" || true
+    fi
+}
+
 bucket() {
-    # $1 = heading, $2 = alternation of conventional types
-    body=$(printf '%s\n' "$log" | grep -E "$(printf '\t')($2)(\(|!?:)" || true)
+    # $1 = heading, $2 = alternation of conventional types, $3 = "-v" to invert
+    body=$(select_types "$2" "${3:-}")
     [ -n "$body" ] || return 0
     printf '### %s\n\n' "$1"
     printf '%s\n' "$body" | while IFS="$(printf '\t')" read -r sha subject; do
@@ -107,11 +123,16 @@ else
     bucket "Fixes" "fix" ""
     bucket "Performance" "perf" ""
     bucket "Reverts" "revert" ""
-    bucket "Other" "build|style" ""
+    # Everything left over: `build`/`style`, and — the reason this is a
+    # complement rather than a list — commits with no conventional prefix at
+    # all. Those used to vanish: the generator claimed to catch them and did
+    # not, so a shallow checkout whose only commit is a merge ("Merge branch
+    # 'main' of …") produced a `## Changes` heading with nothing under it.
+    bucket "Other" "$KNOWN_TYPES" "-v"
 
     # Internal churn is real work but not release-note material; it goes in a
     # fold so the list stays complete without burying the two sections above.
-    internal=$(printf '%s\n' "$log" | grep -E "$(printf '\t')(test|chore|refactor|docs|ci)(\(|!?:)" || true)
+    internal=$(select_types "test|chore|refactor|docs|ci")
     if [ -n "$internal" ]; then
         n=$(printf '%s\n' "$internal" | grep -c .)
         if [ "$n" -eq 1 ]; then noun=commit; else noun=commits; fi

--- a/tests/features/test_build.py
+++ b/tests/features/test_build.py
@@ -971,6 +971,9 @@ def test_site_compare_and_seo():
     actually on the page — invented markup is what gets a site's rich results
     pulled — and a JSON-LD blob that fails to parse is silently ignored by every
     crawler while looking perfectly fine in the browser.
+
+    Read from site/dist when it exists and from the .astro source when it does
+    not — see the fallback below for why insisting on the build was wrong.
     """
     page = _src("site/src/pages/index.astro")
     robots = _src("site/public/robots.txt")
@@ -993,6 +996,19 @@ def test_site_compare_and_seo():
     types = []
     if isinstance(ld, dict):
         types = [n.get("@type") for n in ld.get("@graph", []) if isinstance(n, dict)]
+
+    if not os.path.exists(built):
+        # site/dist is a gitignored build artifact and NO job produces it, so
+        # demanding it made this test unpassable on CI while passing on a dev
+        # box that happened to have a stale build lying around. Fall back to
+        # the source, where the two things that can actually go wrong live:
+        # the blob is machine-serialised, so it cannot be malformed JSON
+        # unless that stops being true, and the @types are written out in the
+        # frontmatter object. When a build IS present the rendered page still
+        # wins, because that is what a crawler reads.
+        ld_ok = "set:html={JSON.stringify(jsonld)}" in page
+        types = [t for t in ("SoftwareApplication", "WebSite")
+                 if '"@type": "%s"' % t in page]
 
     checks = {
         "the matrix names the products it compares against":


### PR DESCRIPTION
`feature-suite` has been failing on `main` itself — the same two Packaging tests, on every run, and therefore on #24, #25 and #26 as well. Neither failure came from a code change; both are defects in the checks.

### `scripts/release-notes.sh` — unprefixed commits were dropped

The `Other` bucket matched only `build|style`, so any commit without a conventional-commit prefix fell through every bucket, contradicting the comment three lines above it. A full-history range hid this because almost everything is prefixed.

CI clones to depth 1. The one reachable commit on `main` is a merge — unprefixed, and grafted, so `--no-merges` doesn't even filter it out. Nothing matched, and `## Changes` rendered as a heading with nothing under it.

`Other` is now the complement of the types that have a section of their own, so every commit is listed exactly once. This was costing real release notes too, not just the test.

### `test_site_compare_and_seo` — depended on an artifact nothing builds

It read the JSON-LD out of `site/dist/index.html`. That path is gitignored and no workflow builds the site, so the check could only pass on a machine that happened to have a stale build. It passed locally, failed on CI, and asserted nothing in either case.

It now falls back to the `.astro` source when there's no build — the blob is emitted via `JSON.stringify`, so it can't be malformed JSON, and the `@type`s are checked in the frontmatter. When a build *is* present the rendered page still wins, since that's what a crawler reads.

### Verification

Reproduced in a depth-1 clone of `main`, which is the CI condition exactly:

- before: `## Changes` empty, `compare/seo: the structured data parses, it describes the app on the page`
- after: both pass — `354 passed / 7 failed`, the 7 being local environment only (no `g++` on PATH in a bare clone, plus the 5 Windows-portability greps that pass on macOS CI)

On this machine the full suite goes 7 failures → 6, the fixed one being the SEO test; the release-notes test passes locally either way because the local clone has full history.

### Note for after this merges

#24, #25 and #26 will keep showing the old red check until their branches are rebased onto the new `main`. Happy to do that so all three go green.