### PR TITLE
Fix torrent search under Zig child runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Keep this independent of `zig build`: the package graph includes the GUI
+  # dependency, so a remote DVUI fetch failure must not hide a regression in
+  # the Zig -> Python child-process seam used by every torrent search.
+  torrent-search-regression:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+      - name: Exercise nova2 through Zig child runtime
+        run: >-
+          zig test -lc --dep io_global
+          -Mroot=tests/nova2_spawn_test.zig
+          -Mio_global=src/core/io_global.zig
+
   # Pure-Zig unit tests — no native deps needed (build.zig's test step compiles
   # only the *_pure.zig modules), so this runs fast on every platform.
   unit-tests:

--- a/build.zig
+++ b/build.zig
@@ -322,6 +322,24 @@ pub fn build(b: *std.Build) void {
     // ── Unit Tests (pure Zig modules only) ──
     const test_step = b.step("test", "Run unit tests");
 
+    // Executable torrent-search seam: nova2 must survive being launched by
+    // Zig's std.Io.Threaded child runtime. This is intentionally offline; the
+    // Python selftest exercises only the app-mode pool dispatcher.
+    const test_nova2_spawn = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("tests/nova2_spawn_test.zig"),
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+        }),
+    });
+    test_nova2_spawn.root_module.addImport("io_global", b.createModule(.{
+        .root_source_file = b.path("src/core/io_global.zig"),
+        .target = target,
+        .optimize = optimize,
+    }));
+    test_step.dependOn(&b.addRunArtifact(test_nova2_spawn).step);
+
     const test_m3u = b.addTest(.{
         .root_module = b.createModule(.{
             .root_source_file = b.path("src/player/m3u.zig"),

--- a/engines/nova2.py
+++ b/engines/nova2.py
@@ -32,6 +32,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import importlib
+import os
 import pathlib
 import sys
 import traceback
@@ -39,9 +40,10 @@ import urllib.parse
 import xml.etree.ElementTree as ET
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
+from concurrent.futures import ThreadPoolExecutor, wait
 from enum import Enum
 from glob import glob
-from multiprocessing import Pool, TimeoutError as PoolTimeoutError, cpu_count
+from multiprocessing import Pool as ProcessPool, TimeoutError as PoolTimeoutError, cpu_count
 from os import path
 from typing import Optional
 
@@ -227,6 +229,53 @@ def run_search(search_params: tuple[type[Engine], str, Category, EngineModuleNam
         return False
 
 
+def run_parallel(params, workers: int, deadline: Optional[float], runner=run_search) -> bool:
+    """Run search jobs using the pool compatible with the calling host.
+
+    Opal is identified by its app-only deadline and must stay entirely inside
+    this Python process. Plain nova2/qBittorrent calls retain the upstream
+    multiprocessing behaviour.
+    """
+    if deadline is not None:
+        # Opal launches nova2 through Zig 0.16's std.Io.Threaded child runtime.
+        # A Python process created that way cannot start multiprocessing's
+        # resource tracker reliably: its registration pipe is already broken by
+        # the time Pool creates its first lock, so nova2 exits immediately with
+        # BrokenPipeError and Opal scans zero rows. concurrent.futures is
+        # genuinely thread-only (multiprocessing.pool.ThreadPool is not on
+        # Python 3.14), and these engines are network-bound.
+        executor = ThreadPoolExecutor(max_workers=workers,
+                                      thread_name_prefix="nova2")
+        futures = [executor.submit(runner, p) for p in params]
+        done, unfinished = wait(futures, timeout=deadline)
+        search_success = all(f.result() for f in done)
+        if unfinished:
+            # Rows are streamed directly by workers, so everything printed
+            # before the deadline remains usable. Python cannot cancel a thread
+            # blocked in a socket call; os._exit is safe because nova2 is a
+            # disposable app subprocess. It preserves the hard deadline without
+            # waiting for ThreadPoolExecutor's non-daemon workers at shutdown.
+            sys.stdout.flush()
+            sys.stderr.flush()
+            os._exit(0)
+        executor.shutdown(wait=True)
+        return search_success
+
+    with ProcessPool(workers) as pool:
+        pending = pool.map_async(runner, params)
+        try:
+            return all(pending.get(timeout=deadline))
+        except PoolTimeoutError:
+            pool.terminate()
+            pool.join()
+            return True
+
+
+def _pool_selftest_task(value: int) -> bool:
+    """Offline task used by the Zig-child regression test."""
+    return value * value >= 0
+
+
 if __name__ == "__main__":
     def main() -> int:
         # https://docs.python.org/3/library/sys.html#sys.exit
@@ -249,6 +298,20 @@ if __name__ == "__main__":
                 print(f"Invalid timeout: {argv[0]}", file=sys.stderr)
                 return ExitCode.ArgError.value
             argv = argv[1:]
+
+        # Offline executable regression seam. This deliberately runs through
+        # the same deadline-mode dispatcher as a real Opal search, so spawning
+        # it from Zig catches the Python resource-tracker BrokenPipe regression
+        # without touching any torrent site.
+        if argv == ["--pool-selftest"]:
+            if deadline is None:
+                print("--pool-selftest requires --timeout", file=sys.stderr)
+                return ExitCode.ArgError.value
+            ok = run_parallel(range(8), 2, deadline, _pool_selftest_task)
+            if ok:
+                print("NOVA2_APP_POOL_OK")
+                return ExitCode.OK.value
+            return ExitCode.AppError.value
 
         found_engines = list_engines()
 
@@ -289,18 +352,7 @@ if __name__ == "__main__":
         search_success = False
         if THREADED:
             processes = max(min(len(engines), MAX_THREADS), 1)
-            with Pool(processes) as pool:
-                pending = pool.map_async(run_search, params)
-                try:
-                    search_success = all(pending.get(timeout=deadline))
-                except PoolTimeoutError:
-                    # Rows are streamed directly by workers, so everything
-                    # printed before the deadline remains usable.  Terminating
-                    # the pool here also guarantees nova2 itself exits instead
-                    # of leaving the Zig worker stuck waiting for EOF.
-                    pool.terminate()
-                    pool.join()
-                    search_success = True
+            search_success = run_parallel(params, processes, deadline)
         else:
             search_success = all(map(run_search, params))
 

--- a/engines/novaprinter.py
+++ b/engines/novaprinter.py
@@ -25,6 +25,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import re
+import threading
 from typing import TypedDict, Union
 
 SearchResults = TypedDict('SearchResults', {
@@ -39,19 +40,20 @@ SearchResults = TypedDict('SearchResults', {
 })
 
 
-# Rows printed by this process. nova2's mirror failover reads it to tell "this
-# host returned nothing" from "this host returned results" without having to
-# intercept stdout.
-results_printed: int = 0
+# Rows printed by the current search worker. nova2's mirror failover reads this
+# to tell "this host returned nothing" from "this host returned results"
+# without intercepting stdout. This must be thread-local: Opal's app-mode
+# fan-out uses threads, and a process-global counter lets a hit from engine A
+# make engine B falsely conclude that its dead primary host returned rows.
+_printed = threading.local()
 
 
 def printed_count() -> int:
-    return results_printed
+    return getattr(_printed, "count", 0)
 
 
 def prettyPrinter(dictionary: SearchResults) -> None:
-    global results_printed
-    results_printed += 1
+    _printed.count = printed_count() + 1
     outtext = "|".join((
         dictionary["link"],
         dictionary["name"].replace("|", " "),

--- a/tests/features/test_engine_health.py
+++ b/tests/features/test_engine_health.py
@@ -544,7 +544,9 @@ def resolve_torrents_has_a_watchdog():
         "pid copied by value": "pid: io_glob.Child.Id" in block,
         # Must NOT reap the child itself — wait() below still owns that.
         "does not kill/reap": "child.kill()" not in block,
-        "still drains then waits": "_ = child.wait() catch {};" in block,
+        # The result is inspected now so a non-zero exit can surface as a
+        # failed source; retaining it is still the same drain-then-wait owner.
+        "still drains then waits": "child.wait()" in block and "const term" in block,
         # Joined before the frame dies, or `&watchdog` dangles.
         "joined before return": "t.join();" in block,
         "has a stop flag": "watchdog.done.store(true, .release)" in block,
@@ -566,6 +568,44 @@ def resolve_torrents_has_a_watchdog():
                         "worst case without being effectively infinite")
     return "pass", (f"nova2 bounded at {secs}s by a separate watchdog thread that "
                     "SIGTERMs by pid; drain-then-wait still reaps")
+
+
+@test("nova2 app mode avoids nested multiprocessing", "Torrents")
+def nova2_app_mode_uses_threads():
+    """Zig 0.16 child processes cannot safely launch Python's resource tracker.
+
+    Opal's nova2 invocation is identified by its app-only ``--timeout`` flag.
+    It must use a thread pool for the network-bound engines; otherwise Pool's
+    first semaphore registration raises BrokenPipeError and every search ends
+    with ``scanned=0 pushed=0``.  The no-deadline qBittorrent CLI keeps the
+    upstream process-pool behaviour.
+    """
+    nv = open(os.path.join(PROJECT_DIR, "engines/nova2.py"),
+              encoding="utf-8").read()
+    checks = {
+        "imports process pool explicitly": "Pool as ProcessPool" in nv,
+        "uses a genuinely thread-only executor": "ThreadPoolExecutor" in nv,
+        "does not use multiprocessing ThreadPool": "multiprocessing.pool import ThreadPool" not in nv,
+        "app deadline selects threads": "def run_parallel(" in nv and "if deadline is not None:" in nv,
+        "still applies the deadline": "wait(futures, timeout=deadline)" in nv,
+        "timeout terminates the disposable child": "os._exit(0)" in nv,
+        "offline Zig-child selftest exists": (
+            'argv == ["--pool-selftest"]' in nv and
+            "NOVA2_APP_POOL_OK" in nv and
+            "tests/nova2_spawn_test.zig" in _src("build.zig")
+        ),
+    }
+    printer = open(os.path.join(PROJECT_DIR, "engines/novaprinter.py"),
+                   encoding="utf-8").read()
+    checks["mirror result counts are thread-local"] = (
+        "threading.local()" in printer and
+        'getattr(_printed, "count", 0)' in printer
+    )
+    missing = [name for name, ok in checks.items() if not ok]
+    if missing:
+        return "fail", "nova2 pool-mode regression: " + ", ".join(missing)
+    return "pass", ("Opal --timeout mode uses network threads; the compatible "
+                    "no-deadline CLI retains multiprocessing")
 
 
 @test("nova2 fetch: a bot wall falls back to the anti-detect browser", "Torrents")

--- a/tests/nova2_spawn_test.zig
+++ b/tests/nova2_spawn_test.zig
@@ -1,0 +1,70 @@
+const std = @import("std");
+const io_global = @import("io_global");
+
+fn workingPython() ?[]const u8 {
+    for ([_][]const u8{ "python3", "python", "py" }) |candidate| {
+        const argv = [_][]const u8{ candidate, "-c", "print('NOVA2_PYTHON_OK')" };
+        var child = io_global.Child.init(&argv, std.testing.allocator);
+        child.stdin_behavior = .Ignore;
+        child.stdout_behavior = .Pipe;
+        child.stderr_behavior = .Ignore;
+        child.spawn() catch continue;
+
+        var buf: [128]u8 = undefined;
+        const n = if (child.stdout) |*out|
+            io_global.readAll(out, &buf) catch 0
+        else
+            0;
+        const term = child.wait() catch continue;
+        const ok = switch (term) {
+            .exited => |code| code == 0,
+            else => false,
+        };
+        if (ok and std.mem.indexOf(u8, buf[0..n], "NOVA2_PYTHON_OK") != null)
+            return candidate;
+    }
+    return null;
+}
+
+// Regression for the exact failure mode that made every installed torrent
+// source return zero rows: nova2 is launched by Zig's std.Io.Threaded runtime,
+// then its app-mode dispatcher fans work out inside Python. A process pool at
+// that seam crashes Python's resource tracker with BrokenPipeError.
+test "nova2 app pool runs when spawned through Zig std.Io" {
+    const python = workingPython() orelse return error.SkipZigTest;
+    const argv = [_][]const u8{
+        python,
+        "engines/nova2.py",
+        "--timeout=2",
+        "--pool-selftest",
+    };
+
+    var child = io_global.Child.init(&argv, std.testing.allocator);
+    child.stdin_behavior = .Ignore;
+    child.stdout_behavior = .Pipe;
+    child.stderr_behavior = .Pipe;
+    try child.spawn();
+
+    var stdout_buf: [4096]u8 = undefined;
+    const stdout_len = if (child.stdout) |*out|
+        try io_global.readAll(out, &stdout_buf)
+    else
+        0;
+    var stderr_buf: [4096]u8 = undefined;
+    const stderr_len = if (child.stderr) |*err|
+        try io_global.readAll(err, &stderr_buf)
+    else
+        0;
+
+    const term = try child.wait();
+    switch (term) {
+        .exited => |code| try std.testing.expectEqual(@as(u8, 0), code),
+        else => return error.UnexpectedTermination,
+    }
+    try std.testing.expectEqual(@as(usize, 0), stderr_len);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        stdout_buf[0..stdout_len],
+        "NOVA2_APP_POOL_OK",
+    ) != null);
+}


### PR DESCRIPTION
## Summary
- avoid nested Python multiprocessing for Opal deadline-mode torrent searches
- preserve the qBittorrent-compatible process-pool path
- make mirror result counters thread-local
- add an offline Zig-child executable regression to `zig build test`

## Root cause
Zig 0.16 `std.Io.Threaded` could launch `nova2.py`, but Python multiprocessing then failed while starting its resource tracker with `BrokenPipeError`. The process exited before emitting a row, leaving Universal Search at `scanned=0 pushed=0`.

## Verification
- `zig build test`
- Python compile checks for `nova2.py` and `novaprinter.py`
- source override and mirror failover feature tests
- watchdog and pool-mode regression tests
- live Opal API search for `ubuntu`: 50 torrent rows, maximum 3,205 seeds

The new Zig test launches the offline `--pool-selftest` through the same `std.Io.Threaded` child seam. Reintroducing multiprocessing on Opal’s deadline path now fails CI.