### PR TITLE
Fix CI dependency fetch for pinned DVUI

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,7 +3,7 @@
     .version = "0.6.4",
     .dependencies = .{
         .dvui = .{
-            .url = "git+https://github.com/debpalash/dvui#c2424c15cbfacfe24d66fda4963055eb4c9ee200",
+            .url = "https://github.com/david-vanderson/dvui/archive/c2424c15cbfacfe24d66fda4963055eb4c9ee200.tar.gz",
             .hash = "dvui-0.5.0-dev-AQFJmeZx2wB8fanD8o3p723w_DUDV851JFja-XOrE8DY",
         },
         .icons = .{


### PR DESCRIPTION
## Summary
- fetch the existing pinned DVUI commit from the public upstream archive
- preserve the exact package content hash and source code
- unblock Linux, Windows, and Docker CI jobs that fail before compilation

## Verification
- archive resolves publicly
- `zig fetch` returns the existing `dvui-0.5.0-dev-AQFJmeZx2wB8fanD8o3p723w_DUDV851JFja-XOrE8DY` hash
- `zig build test` passes with a fresh global cache