### PR TITLE
fix(installer): make Linux installs rootless by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,12 @@ jobs:
           cp zig-out/bin/opal opal-${VERSION}-linux-x86_64/
           cp libtorrent_wrapper.so opal-${VERSION}-linux-x86_64/ 2>/dev/null || true
           cp LICENSE docs/NOTICE.md README.md opal-${VERSION}-linux-x86_64/
+          mkdir -p opal-${VERSION}-linux-x86_64/scripts opal-${VERSION}-linux-x86_64/web
+          cp -r engines opal-${VERSION}-linux-x86_64/
+          cp scripts/camoufox_bridge.py opal-${VERSION}-linux-x86_64/scripts/
+          cp web/index.html opal-${VERSION}-linux-x86_64/web/
+          cp data/plugins-manifest.json data/manga-sources-sfw.json \
+            opal-${VERSION}-linux-x86_64/
           # Desktop entry + icon ride along so downstream repackagers
           # (AUR opal-bin, etc.) can install them from this one artifact.
           cp packaging/opal.desktop opal-${VERSION}-linux-x86_64/
@@ -136,12 +142,17 @@ jobs:
       - name: Package AppImage
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          # Assemble the AppDir by hand: binary + wrapper lib in a private
-          # libdir, desktop file + icon at the AppDir root (appimagetool
-          # requires those), .DirIcon for file managers.
-          mkdir -p AppDir/usr/bin AppDir/usr/lib/opal
-          cp zig-out/bin/opal AppDir/usr/bin/
+          # Keep the executable beside its private wrapper and runtime resources
+          # so main.zig's executable-relative lookup works without /usr paths.
+          # The resource tree is essential: torrent search shells out to nova2,
+          # Plugins reads its manifest, and Web Remote serves web/index.html.
+          mkdir -p AppDir/usr/lib/opal/scripts AppDir/usr/lib/opal/web
+          cp zig-out/bin/opal AppDir/usr/lib/opal/
           cp libtorrent_wrapper.so AppDir/usr/lib/opal/
+          cp -r engines AppDir/usr/lib/opal/
+          cp scripts/camoufox_bridge.py AppDir/usr/lib/opal/scripts/
+          cp web/index.html AppDir/usr/lib/opal/web/
+          cp data/plugins-manifest.json data/manga-sources-sfw.json AppDir/usr/lib/opal/
           cp packaging/opal.desktop AppDir/opal.desktop
           cp assets/logo.svg AppDir/opal.svg
           cp assets/logo.svg AppDir/.DirIcon
@@ -151,7 +162,7 @@ jobs:
           #!/bin/sh
           HERE="${APPDIR:-$(dirname "$(readlink -f "$0")")}"
           export LD_LIBRARY_PATH="$HERE/usr/lib/opal${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-          exec "$HERE/usr/bin/opal" "$@"
+          exec "$HERE/usr/lib/opal/opal" "$@"
           EOF
           chmod +x AppDir/AppRun
           # appimagetool itself ships as an AppImage; the runner has no FUSE,

--- a/README.md
+++ b/README.md
@@ -60,10 +60,18 @@ you left off. One native binary — [Zig](https://ziglang.org) +
 ## 🚀 Get it
 
 One command — detects your platform, verifies checksums, doubles as the updater
-(`… -s -- update`) and version pin (`OPAL_VERSION=v0.1.0 …`):
+(`… -s -- update`) and version pin (`OPAL_VERSION=v0.1.0 …`). On Linux it
+installs to `~/.local` and never needs `sudo`:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/debpalash/Opal/main/scripts/install.sh | sh
+```
+
+For a system-wide Linux install through `apt`, `dnf`, `zypper`, or an AUR
+helper, opt in explicitly (root or `sudo` is required):
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/debpalash/Opal/main/scripts/install.sh | OPAL_SYSTEM=1 sh
 ```
 
 Or pick your row — every file is on [Releases](../../releases):

--- a/packaging/aur/opal-bin/PKGBUILD
+++ b/packaging/aur/opal-bin/PKGBUILD
@@ -35,6 +35,11 @@ package() {
     # resolves from /usr/lib/opal without ldconfig fiddling.
     install -Dm755 opal                  "$pkgdir/usr/bin/opal"
     install -Dm755 libtorrent_wrapper.so "$pkgdir/usr/lib/opal/libtorrent_wrapper.so"
+    cp -r engines                        "$pkgdir/usr/lib/opal/engines"
+    install -Dm755 scripts/camoufox_bridge.py "$pkgdir/usr/lib/opal/scripts/camoufox_bridge.py"
+    install -Dm644 web/index.html        "$pkgdir/usr/lib/opal/web/index.html"
+    install -Dm644 plugins-manifest.json "$pkgdir/usr/lib/opal/plugins-manifest.json"
+    install -Dm644 manga-sources-sfw.json "$pkgdir/usr/lib/opal/manga-sources-sfw.json"
     install -Dm644 opal.desktop          "$pkgdir/usr/share/applications/opal.desktop"
     install -Dm644 opal.svg              "$pkgdir/usr/share/icons/hicolor/scalable/apps/opal.svg"
     install -Dm644 LICENSE               "$pkgdir/usr/share/licenses/$pkgname/LICENSE"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,16 +11,16 @@
 #
 # Options / env:
 #   OPAL_VERSION=v0.1.0   pin any released version (default: latest)
-#   OPAL_PREFIX=~/.local  Linux install prefix for the AppImage (default)
+#   OPAL_PREFIX=~/.local  Linux install prefix (default)
+#   OPAL_SYSTEM=1        use the distro package manager instead (needs root/sudo)
 #
 # Per-platform behavior:
 #   macOS (Apple silicon)  Opal.app → /Applications  (Homebrew tap once live:
 #                          brew install debpalash/tap/opal)
-#   Debian/Ubuntu          installs the official .deb via apt
-#   Fedora/openSUSE        installs the official .rpm via dnf/zypper
-#   Arch                   yay/paru -S opal-bin when available on AUR,
-#                          otherwise falls through to the AppImage
-#   any other Linux        AppImage → $OPAL_PREFIX/bin + desktop entry
+#   Debian/Ubuntu          verified .deb extracted under $OPAL_PREFIX
+#   other Linux            AppImage → $OPAL_PREFIX/bin + desktop entry
+#                          (both paths require no root)
+#   Linux, OPAL_SYSTEM=1   native .deb/.rpm/AUR package (root/sudo required)
 #   Windows                not handled by this script (deliberately — a sh
 #                          installer is the wrong tool there). Download the
 #                          .msi installer or the portable .zip from
@@ -121,26 +121,33 @@ install_macos() {
     say "installed → $target/Opal.app"
 }
 
-install_linux() {
-    arch=$(uname -m)
-    [ "$arch" = "x86_64" ] || die "no prebuilt $arch Linux binaries yet — build from source: https://github.com/$REPO#get-it"
+as_root() {
+    if [ "$(id -u)" -eq 0 ]; then
+        "$@"
+    elif have sudo; then
+        sudo "$@"
+    else
+        die "OPAL_SYSTEM=1 needs root or sudo; omit OPAL_SYSTEM for a user-local install"
+    fi
+}
 
+install_linux_system() {
     if have apt-get; then
         fetch "opal_${VER}_amd64.deb" "$TMP/opal.deb"
-        say "installing .deb (sudo required)"
-        sudo apt-get install -y "$TMP/opal.deb"
+        say "installing system .deb"
+        as_root apt-get install -y "$TMP/opal.deb"
         receipt deb; say "done — run: opal"; return
     fi
     if have dnf; then
         fetch "opal-$VER-1.x86_64.rpm" "$TMP/opal.rpm"
-        say "installing .rpm (sudo required)"
-        sudo dnf install -y "$TMP/opal.rpm"
+        say "installing system .rpm"
+        as_root dnf install -y "$TMP/opal.rpm"
         receipt rpm; say "done — run: opal"; return
     fi
     if have zypper; then
         fetch "opal-$VER-1.x86_64.rpm" "$TMP/opal.rpm"
-        say "installing .rpm (sudo required)"
-        sudo zypper --non-interactive install --allow-unsigned-rpm "$TMP/opal.rpm"
+        say "installing system .rpm"
+        as_root zypper --non-interactive install --allow-unsigned-rpm "$TMP/opal.rpm"
         receipt rpm; say "done — run: opal"; return
     fi
     if have pacman; then
@@ -151,28 +158,114 @@ install_linux() {
                 receipt aur; say "done — run: opal"; return
             fi
         done
-        say "AUR package not reachable — falling back to the AppImage"
+        die "opal-bin is not reachable through yay or paru; omit OPAL_SYSTEM for a user-local install"
     fi
 
-    # Universal fallback: AppImage into the user prefix, no root needed.
-    prefix="${OPAL_PREFIX:-$HOME/.local}"
-    bindir="$prefix/bin"; appdir="$prefix/share/applications"
-    mkdir -p "$bindir" "$appdir"
-    fetch "Opal-$VER-x86_64.AppImage" "$bindir/opal"
-    chmod +x "$bindir/opal"
+    die "no supported system package manager found; omit OPAL_SYSTEM for a user-local install"
+}
+
+write_linux_desktop() {
+    prefix="$1"
+    bindir="$prefix/bin"
+    appdir="$prefix/share/applications"
+    mkdir -p "$appdir"
     cat > "$appdir/opal.desktop" <<EOF
 [Desktop Entry]
 Type=Application
 Name=Opal
 GenericName=Media Suite
-Comment=Play everything — the evolved media player
-Exec=$bindir/opal
+Comment=Play everything — media player, universal search, torrent streaming, local AI
+TryExec=$bindir/opal
+Exec=$bindir/opal %U
+Icon=opal
 Terminal=false
 Categories=AudioVideo;Video;Player;
+MimeType=video/x-matroska;video/mp4;video/webm;video/quicktime;video/x-msvideo;video/mpeg;video/mp2t;video/ogg;audio/mpeg;audio/flac;audio/mp4;audio/aac;audio/ogg;audio/opus;audio/x-wav;audio/x-matroska;audio/x-mpegurl;application/x-mpegURL;application/vnd.apple.mpegurl;application/x-bittorrent;x-scheme-handler/magnet;
+StartupWMClass=opal
 EOF
-    receipt "appimage:$bindir"
+    have update-desktop-database && update-desktop-database "$appdir" >/dev/null 2>&1 || true
+}
+
+install_linux_local_deb() {
+    prefix="$1"
+    root="$TMP/deb-root"
+    bindir="$prefix/bin"
+    libdir="$prefix/lib/opal"
+    icondir="$prefix/share/icons/hicolor/scalable/apps"
+
+    fetch "opal_${VER}_amd64.deb" "$TMP/opal.deb"
+    mkdir -p "$root"
+    dpkg-deb -x "$TMP/opal.deb" "$root" || die "could not unpack the .deb for a user-local install"
+    [ -x "$root/usr/bin/opal" ] || die "the .deb does not contain usr/bin/opal"
+    [ -f "$root/usr/lib/opal/engines/nova2.py" ] || die "the .deb is missing Opal's runtime resources"
+
+    mkdir -p "$bindir" "$icondir"
+    rm -rf "$libdir"
+    mkdir -p "$libdir"
+    cp "$root/usr/bin/opal" "$libdir/opal"
+    cp -R "$root/usr/lib/opal/." "$libdir/"
+    chmod +x "$libdir/opal"
+    if [ -f "$root/usr/share/icons/hicolor/scalable/apps/opal.svg" ]; then
+        cp "$root/usr/share/icons/hicolor/scalable/apps/opal.svg" "$icondir/opal.svg"
+    fi
+
+    # Keep the command on PATH while the actual executable sits beside its
+    # private library and resource tree. That layout lets Opal find nova2 and
+    # the plugin manifests without relying on /usr/lib/opal or the caller's CWD.
+    cat > "$bindir/opal" <<'EOF'
+#!/bin/sh
+bindir=$(CDPATH= cd "$(dirname "$0")" && pwd)
+exec "$bindir/../lib/opal/opal" "$@"
+EOF
+    chmod +x "$bindir/opal"
+    write_linux_desktop "$prefix"
+}
+
+install_linux_local_appimage() {
+    prefix="$1"
+    bindir="$prefix/bin"
+    icondir="$prefix/share/icons/hicolor/scalable/apps"
+    mkdir -p "$bindir" "$icondir"
+    fetch "Opal-$VER-x86_64.AppImage" "$bindir/opal"
+    chmod +x "$bindir/opal"
+
+    # The release AppImage carries the same icon as the native packages.
+    # Extraction does not require FUSE; failure is harmless and leaves the
+    # desktop environment's generic application icon as a fallback.
+    if (cd "$TMP" && "$bindir/opal" --appimage-extract opal.svg >/dev/null 2>&1); then
+        cp "$TMP/squashfs-root/opal.svg" "$icondir/opal.svg"
+    fi
+    write_linux_desktop "$prefix"
+}
+
+install_linux_local() {
+    # Default on every distribution: install only below the user prefix.
+    prefix="${OPAL_PREFIX:-$HOME/.local}"
+    if have dpkg-deb; then
+        # Prefer extraction over the AppImage on Debian-family systems. The
+        # native package includes the complete engines/scripts/web resource
+        # tree and dpkg-deb only unpacks files; it never needs root.
+        install_linux_local_deb "$prefix"
+    else
+        install_linux_local_appimage "$prefix"
+    fi
+
+    receipt "local-prefix:$prefix"
+    bindir="$prefix/bin"
     case ":$PATH:" in *":$bindir:"*) ;; *) say "note: add $bindir to your PATH" ;; esac
-    say "installed → $bindir/opal (AppImage)"
+    say "installed without sudo → $bindir/opal"
+    say "run now: $bindir/opal"
+}
+
+install_linux() {
+    arch=$(uname -m)
+    [ "$arch" = "x86_64" ] || die "no prebuilt $arch Linux binaries yet — build from source: https://github.com/$REPO#get-it"
+
+    case "${OPAL_SYSTEM:-0}" in
+        0) install_linux_local ;;
+        1) install_linux_system ;;
+        *) die "OPAL_SYSTEM must be 0 or 1" ;;
+    esac
 }
 
 do_install() {
@@ -202,6 +295,20 @@ do_uninstall() {
         rpm)         { have dnf && sudo dnf remove -y opal; } || sudo zypper --non-interactive remove opal ;;
         aur)         sudo pacman -R --noconfirm opal-bin ;;
         app:*)       rm -rf "${method#app:}/Opal.app" ;;
+        local-prefix:*)
+            prefix="${method#local-prefix:}"
+            rm -f "$prefix/bin/opal" \
+                  "$prefix/share/applications/opal.desktop" \
+                  "$prefix/share/icons/hicolor/scalable/apps/opal.svg"
+            rm -rf "$prefix/lib/opal"
+            ;;
+        # Backward compatibility with receipts written by v0.6.5 and older.
+        appimage-prefix:*)
+            prefix="${method#appimage-prefix:}"
+            rm -f "$prefix/bin/opal" \
+                  "$prefix/share/applications/opal.desktop" \
+                  "$prefix/share/icons/hicolor/scalable/apps/opal.svg"
+            ;;
         appimage:*)  rm -f "${method#appimage:}/opal" \
                            "${XDG_DATA_HOME:-$HOME/.local/share}/applications/opal.desktop" ;;
         *) die "unknown install method: $method" ;;

--- a/tests/features/test_build.py
+++ b/tests/features/test_build.py
@@ -438,6 +438,110 @@ def test_installer_no_xcode():
     return "pass", "install.sh installs the vendored .app; formula is a binary install at " + f_ver
 
 
+@test("Linux Installer Is Rootless By Default", "Packaging")
+def test_linux_installer_rootless_default():
+    # REGRESSION — distro detection used to force apt/dnf/zypper and sudo even
+    # though Linux releases already publish artifacts suitable for ~/.local.
+    import pathlib
+    import subprocess
+    import tempfile
+
+    sh = _src("scripts/install.sh")
+    release = _src(".github/workflows/release.yml")
+    aur_bin = _src("packaging/aur/opal-bin/PKGBUILD")
+    checks = {
+        "rootless installer exists": "install_linux_local()" in sh,
+        "default selects rootless installer": "0) install_linux_local" in sh,
+        "system install is explicit opt-in": "1) install_linux_system" in sh,
+        "system option is documented": "OPAL_SYSTEM=1" in sh,
+        "local install uses user prefix": '${OPAL_PREFIX:-$HOME/.local}' in sh,
+        "Debian package is unpacked without apt": 'dpkg-deb -x "$TMP/opal.deb"' in sh,
+        "torrent resources required": 'usr/lib/opal/engines/nova2.py' in sh,
+        "local receipt remembers whole prefix": 'receipt "local-prefix:$prefix"' in sh,
+        "desktop launcher uses absolute executable": "TryExec=$bindir/opal" in sh,
+        "future AppImage carries torrent engines": "cp -r engines AppDir/usr/lib/opal/" in release,
+        "AppImage executes beside its resources": 'exec "$HERE/usr/lib/opal/opal"' in release,
+        "tarball carries torrent engines": "cp -r engines opal-${VERSION}-linux-x86_64/" in release,
+        "AUR binary installs torrent engines": 'cp -r engines' in aur_bin,
+    }
+    bad = [name for name, ok in checks.items() if not ok]
+    if bad:
+        return "fail", "rootless Linux installer regression: " + ", ".join(bad)
+
+    # Exercise the default branch with deterministic fake release tools. sudo
+    # is deliberately present but fatal: merely having it on PATH must never
+    # make the rootless installer call it.
+    with tempfile.TemporaryDirectory(prefix="opal-rootless-test-") as td:
+        root = pathlib.Path(td)
+        fakebin = root / "fakebin"
+        home = root / "home"
+        prefix = home / ".local"
+        fakebin.mkdir()
+        home.mkdir()
+
+        def fake(name, body):
+            path = fakebin / name
+            path.write_text("#!/bin/sh\nset -eu\n" + body)
+            path.chmod(0o755)
+
+        fake("uname", 'case "${1:-}" in -m) echo x86_64 ;; *) echo Linux ;; esac\n')
+        fake("sha256sum", 'printf "testhash  %s\\n" "$1"\n')
+        fake("sudo", 'touch "$HOME/sudo-was-called"\nexit 99\n')
+        fake("curl", r'''
+out=""; url=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o) shift; out="$1" ;;
+        http*) url="$1" ;;
+    esac
+    shift
+done
+case "$url" in
+    */SHA256SUMS.txt) printf 'testhash  opal_9.9.9_amd64.deb\n' > "$out" ;;
+    *) : > "$out" ;;
+esac
+''')
+        fake("dpkg-deb", r'''
+dest="$3"
+mkdir -p "$dest/usr/bin" "$dest/usr/lib/opal/engines" \
+         "$dest/usr/share/icons/hicolor/scalable/apps"
+printf '#!/bin/sh\nexit 0\n' > "$dest/usr/bin/opal"
+chmod +x "$dest/usr/bin/opal"
+printf '# nova2 fixture\n' > "$dest/usr/lib/opal/engines/nova2.py"
+printf 'fixture\n' > "$dest/usr/lib/opal/plugins-manifest.json"
+printf '<svg/>\n' > "$dest/usr/share/icons/hicolor/scalable/apps/opal.svg"
+''')
+
+        env = os.environ.copy()
+        env.update({
+            "HOME": str(home),
+            "OPAL_PREFIX": str(prefix),
+            "OPAL_VERSION": "v9.9.9",
+            "PATH": str(fakebin) + os.pathsep + env.get("PATH", ""),
+        })
+        proc = subprocess.run(
+            ["sh", os.path.join(PROJECT_DIR, "scripts/install.sh")],
+            cwd=PROJECT_DIR, env=env, text=True, capture_output=True,
+        )
+        dynamic = {
+            "rootless install exits successfully": proc.returncode == 0,
+            "sudo was not invoked": not (home / "sudo-was-called").exists(),
+            "launcher installed": (prefix / "bin/opal").is_file(),
+            "app installed beside resources": (prefix / "lib/opal/opal").is_file(),
+            "nova2 resource installed": (prefix / "lib/opal/engines/nova2.py").is_file(),
+        }
+        bad = [name for name, ok in dynamic.items() if not ok]
+        if bad:
+            detail = proc.stderr.strip() or proc.stdout.strip()
+            return "fail", "rootless execution failed: " + ", ".join(bad) + " — " + detail[-200:]
+
+        launched = subprocess.run([str(prefix / "bin/opal")], env=env)
+        if launched.returncode != 0:
+            return "fail", "installed user-local launcher did not execute"
+
+    return "pass", "default path calls no sudo and installs executable + nova2 under ~/.local"
+
+
 @test("File associations + single instance", "Packaging")
 def test_file_associations_single_instance():
     # OS default-player registration (macOS/Linux/Windows) + second-instance


### PR DESCRIPTION
## What changed
- make the standard Linux curl installer write under ~/.local without invoking sudo
- keep native apt/dnf/zypper/AUR installation available behind OPAL_SYSTEM=1
- extract the verified Debian package user-locally on Ubuntu so torrent engines and plugin resources remain available
- include the runtime resource tree in future AppImage and tarball artifacts, and install it from opal-bin
- add a regression that provides a fatal fake sudo and proves the default path never calls it

## Verified
- live v0.6.5 download and SHA-256 verification into an isolated temporary HOME
- installed launcher, nova2 torrent engine, and plugin manifests verified; rootless uninstall verified
- zig build test
- installer/AUR/workflow packaging regression tests
- sh -n scripts/install.sh
- bash -n packaging/aur/opal-bin/PKGBUILD
- git diff --check