### PR TITLE
perf: harden render and background ingest paths

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -392,6 +392,15 @@ pub fn build(b: *std.Build) void {
     });
     test_step.dependOn(&b.addRunArtifact(test_m3u).step);
 
+    const test_playback_snapshot_pure = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/player/playback_snapshot_pure.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    test_step.dependOn(&b.addRunArtifact(test_playback_snapshot_pure).step);
+
     const test_paths = b.addTest(.{
         .root_module = b.createModule(.{
             .root_source_file = b.path("src/core/paths.zig"),

--- a/src/core/state.zig
+++ b/src/core/state.zig
@@ -601,14 +601,14 @@ pub const AppState = struct {
     pending_source_url_len: usize = 0,
     dropped_file_path: [2048]u8 = std.mem.zeroes([2048]u8),
     dropped_file_len: usize = 0,
-    dropped_file_ready: bool = false,
+    dropped_file_ready: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     dropped_file_lock: @import("sync.zig").Mutex = .{},
     // Path/URL forwarded by a second `opal <file>` launch (remote /api/open,
     // written on an API connection thread). appFrame consumes it on the UI
     // thread via browser.loadContent — the same route a direct CLI open takes.
     remote_open_path: [2048]u8 = std.mem.zeroes([2048]u8),
     remote_open_len: usize = 0,
-    remote_open_ready: bool = false,
+    remote_open_ready: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     remote_open_lock: @import("sync.zig").Mutex = .{},
     // Typed routing + rich metadata for a remote open/ingest (browser extension).
     // Populated under remote_open_lock alongside remote_open_path; consumed once

--- a/src/main.zig
+++ b/src/main.zig
@@ -485,6 +485,7 @@ pub fn appDeinit() void {
     // leak check races their still-live tmp_buf/p_slice. Workers poll isQuitting
     // in their read loops, so this drains in well under the timeout.
     @import("core/workers.zig").beginShutdownAndDrain(800);
+    @import("player/drop_ingest.zig").deinit();
 
     // Drop the macOS Now Playing card before the players go away (no-op elsewhere).
     @import("player/media_remote.zig").clear();
@@ -568,47 +569,6 @@ fn hexVal(ch: u8) ?u8 {
     return null;
 }
 
-fn isDirectory(path: []const u8) bool {
-    if (path.len == 0) return false;
-    var dir = if (path[0] == '/')
-        @import("core/io_global.zig").openDirAbsolute(path, .{ .iterate = false }) catch return false
-    else
-        @import("core/io_global.zig").cwdOpenDir(path, .{ .iterate = false }) catch return false;
-    dir.close(@import("core/io_global.zig").io());
-    return true;
-}
-
-const media_exts = [_][]const u8{ ".mp4", ".mkv", ".avi", ".webm", ".mov", ".flv", ".ts", ".mp3", ".flac", ".wav", ".ogg", ".m4a", ".opus" };
-
-fn isMediaFile(name: []const u8) bool {
-    for (media_exts) |ext| {
-        if (name.len > ext.len and std.ascii.eqlIgnoreCase(name[name.len - ext.len ..], ext)) return true;
-    }
-    return false;
-}
-
-fn scanDirForMedia(pl: *@import("player/m3u.zig").M3UPlaylist, dir_path: []const u8) void {
-    var dir = if (dir_path.len > 0 and dir_path[0] == '/')
-        @import("core/io_global.zig").openDirAbsolute(dir_path, .{ .iterate = true }) catch return
-    else
-        @import("core/io_global.zig").cwdOpenDir(dir_path, .{ .iterate = true }) catch return;
-    defer dir.close(@import("core/io_global.zig").io());
-    var it = dir.iterate();
-    while (it.next(@import("core/io_global.zig").io()) catch null) |entry| {
-        if (entry.kind != .file) continue;
-        if (!isMediaFile(entry.name)) continue;
-        // Build full absolute path
-        var full_buf: [4096]u8 = undefined;
-        const full_path = std.fmt.bufPrint(&full_buf, "{s}/{s}", .{ dir_path, entry.name }) catch continue;
-        pl.entries.append(pl.allocator, .{
-            .title = pl.allocator.dupe(u8, entry.name) catch continue,
-            .url = pl.allocator.dupe(u8, full_path) catch continue,
-            .logoUrl = null,
-            .group = pl.allocator.dupe(u8, "Local") catch null,
-        }) catch {};
-    }
-}
-
 fn sdlEventWatch(_: ?*anyopaque, event: [*c]c.sdl.SDL_Event) callconv(.c) c_int {
     const t = event.*.type;
     // Log drops or unknown things to see what Wayland is sending
@@ -647,7 +607,7 @@ fn sdlEventWatch(_: ?*anyopaque, event: [*c]c.sdl.SDL_Event) callconv(.c) c_int 
             @memcpy(state.app.dropped_file_path[0..di], decoded[0..di]);
             state.app.dropped_file_path[di] = 0;
             state.app.dropped_file_len = di;
-            state.app.dropped_file_ready = true;
+            state.app.dropped_file_ready.store(true, .release);
             c.sdl.SDL_free(file_c_str);
         }
     }
@@ -887,75 +847,67 @@ fn appFrame() !dvui.App.Result {
         }
     }
 
-    // Process dropped files
-    state.app.dropped_file_lock.lock();
-    if (state.app.dropped_file_ready) {
-        state.app.dropped_file_ready = false;
-        if (state.app.dropped_file_len > 0 and state.app.active_player_idx < state.app.players.items.len) {
-            const fpath = state.app.dropped_file_path[0..state.app.dropped_file_len];
-            if (std.mem.endsWith(u8, fpath, ".m3u") or std.mem.endsWith(u8, fpath, ".m3u8")) {
-                // It's an M3U file, load it!
-                const m3u = @import("player/m3u.zig");
-                if (state.app.playlist) |pl| {
-                    const mut_pl = @constCast(pl);
-                    mut_pl.deinit();
-                    @import("core/alloc.zig").allocator.destroy(mut_pl);
-                }
-                const new_pl = @import("core/alloc.zig").allocator.create(m3u.M3UPlaylist) catch null;
-                if (new_pl) |pl| {
-                    pl.* = m3u.M3UPlaylist.init(@import("core/alloc.zig").allocator);
-                    pl.loadFile(@import("core/io_global.zig").io(), fpath) catch {};
-                    state.app.playlist = pl;
-                    state.app.playlist_drawer_open = true;
-                    logs.pushLog("info", "m3u", "Loaded M3U playlist", false);
-                    state.showToast("Playlist loaded!");
-                }
-            } else if (isDirectory(fpath)) {
-                // Folder drop — scan for media files and build auto-playlist
-                const m3u = @import("player/m3u.zig");
-                if (state.app.playlist) |pl| {
-                    const mut_pl = @constCast(pl);
-                    mut_pl.deinit();
-                    @import("core/alloc.zig").allocator.destroy(mut_pl);
-                }
-                const new_pl = @import("core/alloc.zig").allocator.create(m3u.M3UPlaylist) catch null;
-                if (new_pl) |pl| {
-                    pl.* = m3u.M3UPlaylist.init(@import("core/alloc.zig").allocator);
-                    scanDirForMedia(pl, fpath);
-                    if (pl.entries.items.len > 0) {
-                        state.app.playlist = pl;
-                        state.app.playlist_drawer_open = true;
-                        logs.pushLog("info", "folder", "Scanned folder for media", false);
-                        state.showToast("Folder loaded as playlist!");
-                    } else {
-                        pl.deinit();
-                        @import("core/alloc.zig").allocator.destroy(pl);
-                        state.app.playlist = null;
-                        logs.pushLog("warn", "folder", "No media files found", false);
-                    }
-                }
-            } else if (@import("services/browser_pure.zig").routeContent(fpath) == .torrent) {
-                // A dropped .torrent is metadata, not media — handing it to mpv
-                // just errors out. Only the torrent route is taken from the
-                // (unit-tested) router here; every other shape keeps the existing
-                // straight-to-mpv drop behavior below.
-                @import("services/search.zig").addTorrentFileToEngine(fpath);
-                logs.pushLog("info", "open", "Loaded dropped .torrent", false);
-                state.showToast("Adding torrent...");
-            } else {
-                // Clear resume position so dropped file starts fresh
-                _ = c.mpv.mpv_set_option_string(
-                    state.app.players.items[state.app.active_player_idx].mpv_ctx,
-                    "start",
-                    "0",
-                );
-                state.app.players.items[state.app.active_player_idx].load_file(@ptrCast(&state.app.dropped_file_path[0]));
-                logs.pushLog("info", "open", "Loaded dropped file", false);
-                state.showToast("Playing dropped file");
-            }
+    // Process dropped files. The atomic ready bit makes the idle frame path a
+    // single acquire-load instead of a mutex round trip. Snapshot under the
+    // lock, then release it before any filesystem or player work.
+    var dropped_buf: [2048:0]u8 = std.mem.zeroes([2048:0]u8);
+    var dropped_len: usize = 0;
+    if (state.app.dropped_file_ready.load(.acquire)) {
+        state.app.dropped_file_lock.lock();
+        if (state.app.dropped_file_ready.swap(false, .acq_rel)) {
+            dropped_len = @min(state.app.dropped_file_len, dropped_buf.len);
+            @memcpy(dropped_buf[0..dropped_len], state.app.dropped_file_path[0..dropped_len]);
+        }
+        state.app.dropped_file_lock.unlock();
+    }
+    if (dropped_len > 0) {
+        if (@import("player/drop_ingest.zig").start(dropped_buf[0..dropped_len])) {
+            state.showToast("Opening dropped item...");
+        } else {
+            logs.pushLog("error", "open", "Could not start dropped-item worker", true);
         }
     }
-    state.app.dropped_file_lock.unlock();
+
+    // Folder traversal and M3U parsing finish here, never in the render path.
+    if (@import("player/drop_ingest.zig").take()) |drop_const| {
+        var drop = drop_const;
+        defer drop.deinit();
+        switch (drop.kind) {
+            .playlist => if (drop.playlist) |playlist| {
+                if (state.app.playlist) |old| {
+                    old.deinit();
+                    @import("core/alloc.zig").allocator.destroy(old);
+                }
+                state.app.playlist = playlist;
+                drop.playlist = null; // ownership moved into AppState
+                state.app.playlist_drawer_open = true;
+                logs.pushLog("info", "playlist", "Loaded dropped playlist", false);
+                state.showToast("Playlist loaded!");
+            },
+            .empty_folder => {
+                logs.pushLog("warn", "folder", "No media files found", false);
+                state.showToast("No media files found");
+            },
+            .invalid_playlist => {
+                logs.pushLog("error", "m3u", "Could not read dropped playlist", true);
+                state.showToast("Could not read playlist");
+            },
+            .path => if (state.app.active_player_idx < state.app.players.items.len) {
+                const fpath = drop.pathSlice();
+                if (@import("services/browser_pure.zig").routeContent(fpath) == .torrent) {
+                    @import("services/search.zig").addTorrentFileToEngine(fpath);
+                    logs.pushLog("info", "open", "Loaded dropped .torrent", false);
+                    state.showToast("Adding torrent...");
+                } else {
+                    const active = state.app.players.items[state.app.active_player_idx];
+                    _ = c.mpv.mpv_set_option_string(active.mpv_ctx, "start", "0");
+                    active.load_file(@ptrCast(&drop.path[0]));
+                    logs.pushLog("info", "open", "Loaded dropped file", false);
+                    state.showToast("Playing dropped file");
+                }
+            },
+        }
+    }
 
     // Process CLI file argument (deferred from appInit)
     if (!cli_open_done and cli_open_len > 0 and state.app.players.items.len > 0) {
@@ -982,26 +934,27 @@ fn appFrame() !dvui.App.Result {
         var art_len: usize = 0;
         var sub_buf: [256]u8 = undefined;
         var sub_len: usize = 0;
-        state.app.remote_open_lock.lock();
-        if (state.app.remote_open_ready) {
-            state.app.remote_open_ready = false;
-            fwd_len = state.app.remote_open_len;
-            @memcpy(fwd_buf[0..fwd_len], state.app.remote_open_path[0..fwd_len]);
-            type_len = state.app.remote_open_type_len;
-            @memcpy(type_buf[0..type_len], state.app.remote_open_type[0..type_len]);
-            title_len = state.app.remote_open_title_len;
-            @memcpy(title_buf[0..title_len], state.app.remote_open_title[0..title_len]);
-            art_len = state.app.remote_open_art_len;
-            @memcpy(art_buf[0..art_len], state.app.remote_open_art[0..art_len]);
-            sub_len = state.app.remote_open_subtitle_len;
-            @memcpy(sub_buf[0..sub_len], state.app.remote_open_subtitle[0..sub_len]);
-            // One-shot: clear the meta so a later bare open doesn't reuse it.
-            state.app.remote_open_type_len = 0;
-            state.app.remote_open_title_len = 0;
-            state.app.remote_open_art_len = 0;
-            state.app.remote_open_subtitle_len = 0;
+        if (state.app.remote_open_ready.load(.acquire)) {
+            state.app.remote_open_lock.lock();
+            if (state.app.remote_open_ready.swap(false, .acq_rel)) {
+                fwd_len = state.app.remote_open_len;
+                @memcpy(fwd_buf[0..fwd_len], state.app.remote_open_path[0..fwd_len]);
+                type_len = state.app.remote_open_type_len;
+                @memcpy(type_buf[0..type_len], state.app.remote_open_type[0..type_len]);
+                title_len = state.app.remote_open_title_len;
+                @memcpy(title_buf[0..title_len], state.app.remote_open_title[0..title_len]);
+                art_len = state.app.remote_open_art_len;
+                @memcpy(art_buf[0..art_len], state.app.remote_open_art[0..art_len]);
+                sub_len = state.app.remote_open_subtitle_len;
+                @memcpy(sub_buf[0..sub_len], state.app.remote_open_subtitle[0..sub_len]);
+                // One-shot: clear the meta so a later bare open doesn't reuse it.
+                state.app.remote_open_type_len = 0;
+                state.app.remote_open_title_len = 0;
+                state.app.remote_open_art_len = 0;
+                state.app.remote_open_subtitle_len = 0;
+            }
+            state.app.remote_open_lock.unlock();
         }
-        state.app.remote_open_lock.unlock();
         if (fwd_len > 0) {
             const url = fwd_buf[0..fwd_len];
             const kind = type_buf[0..type_len];

--- a/src/player/drop_ingest.zig
+++ b/src/player/drop_ingest.zig
@@ -1,0 +1,186 @@
+const std = @import("std");
+const io_global = @import("../core/io_global.zig");
+const state = @import("../core/state.zig");
+const workers = @import("../core/workers.zig");
+const m3u = @import("m3u.zig");
+
+// A dropped network mount can remain blocked past the bounded global shutdown
+// drain. Keep this worker's allocations independent of the debug allocator
+// that appDeinit tears down after that deadline.
+const allocator = std.heap.c_allocator;
+
+const max_path_len = 2048;
+const max_folder_entries = 10_000;
+
+pub const Kind = enum { path, playlist, empty_folder, invalid_playlist };
+
+pub const Result = struct {
+    path: [max_path_len:0]u8 = std.mem.zeroes([max_path_len:0]u8),
+    path_len: usize = 0,
+    kind: Kind = .path,
+    playlist: ?*m3u.M3UPlaylist = null,
+
+    pub fn pathSlice(self: *const Result) []const u8 {
+        return self.path[0..self.path_len];
+    }
+
+    pub fn deinit(self: *Result) void {
+        if (self.playlist) |playlist| {
+            playlist.deinit();
+            allocator.destroy(playlist);
+            self.playlist = null;
+        }
+    }
+};
+
+const Args = struct {
+    path: [max_path_len:0]u8 = std.mem.zeroes([max_path_len:0]u8),
+    path_len: usize = 0,
+    generation: u64,
+};
+
+var generation = std.atomic.Value(u64).init(0);
+var result_ready = std.atomic.Value(bool).init(false);
+var result_lock: @import("../core/sync.zig").Mutex = .{};
+var pending: ?Result = null;
+
+/// Start classifying/loading a dropped path away from the UI thread. Newer
+/// drops supersede older work; stale workers free their result instead of
+/// publishing it.
+pub fn start(path: []const u8) bool {
+    if (path.len == 0 or workers.isQuitting()) return false;
+    const args = allocator.create(Args) catch return false;
+    args.* = .{ .generation = generation.fetchAdd(1, .acq_rel) + 1 };
+    args.path_len = @min(path.len, args.path.len);
+    @memcpy(args.path[0..args.path_len], path[0..args.path_len]);
+
+    // Register before spawning so shutdown cannot observe zero active workers
+    // in the gap between spawn and the new thread entering its body.
+    workers.enter();
+    const thread = std.Thread.spawn(.{}, run, .{args}) catch {
+        workers.leave();
+        allocator.destroy(args);
+        return false;
+    };
+    thread.detach();
+    return true;
+}
+
+/// Non-blocking UI-thread drain. The idle path is one atomic load.
+pub fn take() ?Result {
+    if (!result_ready.load(.acquire)) return null;
+    result_lock.lock();
+    defer result_lock.unlock();
+    if (!result_ready.swap(false, .acq_rel)) return null;
+    const out = pending;
+    pending = null;
+    return out;
+}
+
+/// Call after the global worker barrier during app shutdown.
+pub fn deinit() void {
+    if (take()) |value_const| {
+        var value = value_const;
+        value.deinit();
+    }
+}
+
+fn run(args: *Args) void {
+    defer workers.leave();
+    defer allocator.destroy(args);
+
+    var result = classify(args.path[0..args.path_len]);
+    if (workers.isQuitting() or args.generation != generation.load(.acquire)) {
+        result.deinit();
+        return;
+    }
+
+    result_lock.lock();
+    if (workers.isQuitting() or args.generation != generation.load(.acquire)) {
+        result_lock.unlock();
+        result.deinit();
+        return;
+    }
+    if (pending) |old_const| {
+        var old = old_const;
+        old.deinit();
+    }
+    pending = result;
+    result_ready.store(true, .release);
+    result_lock.unlock();
+    state.wakeUi();
+}
+
+fn classify(path: []const u8) Result {
+    var result = Result{};
+    result.path_len = @min(path.len, result.path.len);
+    @memcpy(result.path[0..result.path_len], path[0..result.path_len]);
+
+    const playlist = allocator.create(m3u.M3UPlaylist) catch return result;
+    playlist.* = m3u.M3UPlaylist.init(allocator);
+
+    if (hasPlaylistExtension(path)) {
+        playlist.loadFile(io_global.io(), path) catch {
+            playlist.deinit();
+            allocator.destroy(playlist);
+            result.kind = .invalid_playlist;
+            return result;
+        };
+        result.kind = .playlist;
+        result.playlist = playlist;
+        return result;
+    }
+
+    if (!scanDirectory(playlist, path)) {
+        playlist.deinit();
+        allocator.destroy(playlist);
+        return result;
+    }
+    if (playlist.entries.items.len == 0) {
+        playlist.deinit();
+        allocator.destroy(playlist);
+        result.kind = .empty_folder;
+        return result;
+    }
+    result.kind = .playlist;
+    result.playlist = playlist;
+    return result;
+}
+
+fn scanDirectory(playlist: *m3u.M3UPlaylist, dir_path: []const u8) bool {
+    var dir = if (dir_path.len > 0 and dir_path[0] == '/')
+        io_global.openDirAbsolute(dir_path, .{ .iterate = true }) catch return false
+    else
+        io_global.cwdOpenDir(dir_path, .{ .iterate = true }) catch return false;
+    defer dir.close(io_global.io());
+
+    var iterator = dir.iterate();
+    while (playlist.entries.items.len < max_folder_entries) {
+        if (workers.isQuitting()) return true;
+        const entry = (iterator.next(io_global.io()) catch return true) orelse break;
+        if (entry.kind != .file or !isMediaFile(entry.name)) continue;
+        var full_buf: [4096]u8 = undefined;
+        const full_path = std.fmt.bufPrint(&full_buf, "{s}/{s}", .{ dir_path, entry.name }) catch continue;
+        playlist.appendCopy(entry.name, full_path, null, "Local") catch continue;
+    }
+    return true;
+}
+
+fn hasPlaylistExtension(path: []const u8) bool {
+    return endsWithIgnoreCase(path, ".m3u") or endsWithIgnoreCase(path, ".m3u8");
+}
+
+fn isMediaFile(name: []const u8) bool {
+    const extensions = [_][]const u8{
+        ".mp4", ".mkv",  ".avi", ".webm", ".mov", ".flv",  ".ts",
+        ".mp3", ".flac", ".wav", ".ogg",  ".m4a", ".opus",
+    };
+    for (extensions) |extension| {
+        if (endsWithIgnoreCase(name, extension)) return true;
+    }
+    return false;
+}
+
+fn endsWithIgnoreCase(value: []const u8, suffix: []const u8) bool {
+    return value.len > suffix.len and std.ascii.eqlIgnoreCase(value[value.len - suffix.len ..], suffix);
+}

--- a/src/player/m3u.zig
+++ b/src/player/m3u.zig
@@ -28,6 +28,32 @@ pub const M3UPlaylist = struct {
         self.entries.deinit(self.allocator);
     }
 
+    /// Append a fully-owned entry with rollback on every allocation failure.
+    /// Centralizing this prevents partially-built playlist rows from leaking.
+    pub fn appendCopy(
+        self: *M3UPlaylist,
+        title: []const u8,
+        url: []const u8,
+        logo_url: ?[]const u8,
+        group: ?[]const u8,
+    ) !void {
+        const owned_title = try self.allocator.dupe(u8, title);
+        errdefer self.allocator.free(owned_title);
+        const owned_url = try self.allocator.dupe(u8, url);
+        errdefer self.allocator.free(owned_url);
+        const owned_logo = if (logo_url) |value| try self.allocator.dupe(u8, value) else null;
+        errdefer if (owned_logo) |value| self.allocator.free(value);
+        const owned_group = if (group) |value| try self.allocator.dupe(u8, value) else null;
+        errdefer if (owned_group) |value| self.allocator.free(value);
+
+        try self.entries.append(self.allocator, .{
+            .title = owned_title,
+            .url = owned_url,
+            .logoUrl = owned_logo,
+            .group = owned_group,
+        });
+    }
+
     /// Caller passes io so this file stays self-contained (unit tests
     /// build m3u.zig as a standalone module — imports outside its
     /// dir would violate module boundaries).
@@ -107,12 +133,7 @@ pub const M3UPlaylist = struct {
                     }
                 }
 
-                try self.entries.append(self.allocator, .{
-                    .title = try self.allocator.dupe(u8, current_title.?),
-                    .url = try self.allocator.dupe(u8, line),
-                    .logoUrl = if (current_logo) |cl| try self.allocator.dupe(u8, cl) else null,
-                    .group = if (current_group) |cg| try self.allocator.dupe(u8, cg) else null,
-                });
+                try self.appendCopy(current_title.?, line, current_logo, current_group);
 
                 // Reset for next entry
                 current_title = null;

--- a/src/player/playback_snapshot_pure.zig
+++ b/src/player/playback_snapshot_pure.zig
@@ -1,0 +1,72 @@
+const std = @import("std");
+
+/// One coherent, allocation-free view of the mpv properties needed by the UI.
+/// MediaPlayer updates it from property-change events; render code only reads it.
+pub const Snapshot = struct {
+    paused: bool = true,
+    paused_for_cache: bool = false,
+    time_pos: f64 = 0,
+    duration: f64 = 0,
+    volume: f64 = 100,
+    speed: f64 = 1,
+    muted: bool = false,
+    playlist_count: i64 = 0,
+    playlist_pos: i64 = 0,
+    video_width: i64 = 0,
+    video_height: i64 = 0,
+
+    pub fn percent(self: Snapshot) f64 {
+        const pos = finiteNonNegative(self.time_pos);
+        const dur = finiteNonNegative(self.duration);
+        if (dur <= 0) return 0;
+        return std.math.clamp(pos / dur * 100.0, 0.0, 100.0);
+    }
+};
+
+pub const RenderSize = struct { width: u32, height: u32 };
+
+/// Fit the decoded video into the reusable software-render buffer without
+/// upscaling smaller sources. Invalid/unavailable metadata uses the full buffer.
+pub fn renderSize(video_width: i64, video_height: i64, max_width: u32, max_height: u32) RenderSize {
+    if (video_width <= 0 or video_height <= 0 or max_width < 2 or max_height < 2)
+        return .{ .width = max_width, .height = max_height };
+
+    const vw: u64 = @intCast(video_width);
+    const vh: u64 = @intCast(video_height);
+    if (vw <= max_width and vh <= max_height)
+        return .{ .width = @intCast(vw), .height = @intCast(vh) };
+
+    // Integer math keeps this deterministic and avoids precision loss on
+    // malformed, extremely large dimensions.
+    const width_limited = @as(u128, vw) * max_height > @as(u128, vh) * max_width;
+    if (width_limited) {
+        return .{
+            .width = max_width,
+            .height = @max(2, @as(u32, @intCast(@as(u128, vh) * max_width / vw))),
+        };
+    }
+    return .{
+        .width = @max(2, @as(u32, @intCast(@as(u128, vw) * max_height / vh))),
+        .height = max_height,
+    };
+}
+
+fn finiteNonNegative(value: f64) f64 {
+    if (!std.math.isFinite(value) or value < 0) return 0;
+    return value;
+}
+
+test "snapshot percent is finite and clamped" {
+    try std.testing.expectEqual(@as(f64, 25), (Snapshot{ .time_pos = 30, .duration = 120 }).percent());
+    try std.testing.expectEqual(@as(f64, 100), (Snapshot{ .time_pos = 121, .duration = 120 }).percent());
+    try std.testing.expectEqual(@as(f64, 0), (Snapshot{ .time_pos = std.math.nan(f64), .duration = 120 }).percent());
+    try std.testing.expectEqual(@as(f64, 0), (Snapshot{ .time_pos = 1, .duration = 0 }).percent());
+}
+
+test "render size preserves aspect and never upscales" {
+    try std.testing.expectEqual(RenderSize{ .width = 1280, .height = 720 }, renderSize(1280, 720, 1920, 1080));
+    try std.testing.expectEqual(RenderSize{ .width = 1920, .height = 1080 }, renderSize(3840, 2160, 1920, 1080));
+    try std.testing.expectEqual(RenderSize{ .width = 607, .height = 1080 }, renderSize(1080, 1920, 1920, 1080));
+    try std.testing.expectEqual(RenderSize{ .width = 1920, .height = 1080 }, renderSize(0, 0, 1920, 1080));
+    try std.testing.expectEqual(RenderSize{ .width = 1920, .height = 2 }, renderSize(std.math.maxInt(i64), 1, 1920, 1080));
+}

--- a/src/player/player.zig
+++ b/src/player/player.zig
@@ -4,7 +4,9 @@ const c = @import("../core/c.zig");
 const state = @import("../core/state.zig");
 const logs = @import("../core/logs.zig");
 const http_headers = @import("http_headers_pure.zig");
+const playback_snapshot = @import("playback_snapshot_pure.zig");
 pub const HttpHeader = http_headers.HttpHeader;
+pub const PlaybackSnapshot = playback_snapshot.Snapshot;
 
 /// True if a Firefox profile dir exists, so yt-dlp's --cookies-from-browser
 /// firefox won't abort. Checked once and cached.
@@ -74,6 +76,15 @@ pub const MediaPlayer = struct {
     // path doesn't issue synchronous IPC (or per-frame allocations) for these.
     cached_paused: bool = true, // mirror of mpv "pause"
     last_seen_pos: f64 = 0, // last valid mpv time-pos seen in the event loop (co-watch rewind detect)
+    cached_duration: f64 = 0,
+    cached_volume: f64 = 100,
+    cached_speed: f64 = 1,
+    cached_muted: bool = false,
+    cached_paused_for_cache: bool = false,
+    cached_playlist_count: i64 = 0,
+    cached_playlist_pos: i64 = 0,
+    cached_video_width: i64 = 0,
+    cached_video_height: i64 = 0,
     // True only when this player is playing ANIME-sourced media (armed by the
     // anime play flow via services/anime_skip.zig). Gates auto-skip so we
     // don't apply crowdsourced anime timestamps to arbitrary files.
@@ -159,6 +170,25 @@ pub const MediaPlayer = struct {
     // free the stale texture and re-fetch the correct art once the worker lands
     // (same leak-free swap the podcasts cover slots use).
     np_art_url_hash: u64 = 0,
+
+    /// Allocation-free render snapshot. All fields are mirrors maintained by
+    /// mpv property-change events, so callers never synchronously cross into
+    /// libmpv while laying out a frame.
+    pub fn playbackSnapshot(self: *const MediaPlayer) PlaybackSnapshot {
+        return .{
+            .paused = self.cached_paused,
+            .paused_for_cache = self.cached_paused_for_cache,
+            .time_pos = self.last_seen_pos,
+            .duration = self.cached_duration,
+            .volume = self.cached_volume,
+            .speed = self.cached_speed,
+            .muted = self.cached_muted,
+            .playlist_count = self.cached_playlist_count,
+            .playlist_pos = self.cached_playlist_pos,
+            .video_width = self.cached_video_width,
+            .video_height = self.cached_video_height,
+        };
+    }
 
     /// Set (or clear, with empty args) the now-playing audio metadata + cover
     /// art. UI-thread only. Copies the strings in (clamped) and releases any
@@ -354,6 +384,15 @@ pub const MediaPlayer = struct {
         // when the sub-text mirror is drawn. Initialize them to their defaults.
         self.cached_paused = true;
         self.last_seen_pos = 0;
+        self.cached_duration = 0;
+        self.cached_volume = 100;
+        self.cached_speed = 1;
+        self.cached_muted = false;
+        self.cached_paused_for_cache = false;
+        self.cached_playlist_count = 0;
+        self.cached_playlist_pos = 0;
+        self.cached_video_width = 0;
+        self.cached_video_height = 0;
         self.anime_skip_active = false;
         self.cached_vid_no = false;
         self.vis_applied = false;
@@ -591,6 +630,15 @@ pub const MediaPlayer = struct {
         // time-pos drives co-watch rewind detection even during silent stretches
         // (no subtitle change). Value arrives in the event payload — no per-frame IPC.
         _ = c.mpv.mpv_observe_property(self.mpv_ctx, 0, "time-pos", c.mpv.MPV_FORMAT_DOUBLE);
+        _ = c.mpv.mpv_observe_property(self.mpv_ctx, 0, "duration", c.mpv.MPV_FORMAT_DOUBLE);
+        _ = c.mpv.mpv_observe_property(self.mpv_ctx, 0, "volume", c.mpv.MPV_FORMAT_DOUBLE);
+        _ = c.mpv.mpv_observe_property(self.mpv_ctx, 0, "speed", c.mpv.MPV_FORMAT_DOUBLE);
+        _ = c.mpv.mpv_observe_property(self.mpv_ctx, 0, "mute", c.mpv.MPV_FORMAT_FLAG);
+        _ = c.mpv.mpv_observe_property(self.mpv_ctx, 0, "paused-for-cache", c.mpv.MPV_FORMAT_FLAG);
+        _ = c.mpv.mpv_observe_property(self.mpv_ctx, 0, "playlist-count", c.mpv.MPV_FORMAT_INT64);
+        _ = c.mpv.mpv_observe_property(self.mpv_ctx, 0, "playlist-pos", c.mpv.MPV_FORMAT_INT64);
+        _ = c.mpv.mpv_observe_property(self.mpv_ctx, 0, "dwidth", c.mpv.MPV_FORMAT_INT64);
+        _ = c.mpv.mpv_observe_property(self.mpv_ctx, 0, "dheight", c.mpv.MPV_FORMAT_INT64);
 
         // Load enabled user scripts individually (must happen after mpv_initialize)
         for (0..state.app.script_count) |si| {
@@ -1139,6 +1187,22 @@ fn getPropStringInto(ctx: ?*c.mpv.mpv_handle, name: [*:0]const u8, buf: []u8) []
     return buf[0..n];
 }
 
+fn eventDouble(pc: *const c.mpv.mpv_event_property, fallback: f64) f64 {
+    if (pc.format != c.mpv.MPV_FORMAT_DOUBLE or pc.data == null) return fallback;
+    const value = @as(*const f64, @ptrCast(@alignCast(pc.data))).*;
+    return if (std.math.isFinite(value)) value else fallback;
+}
+
+fn eventInt64(pc: *const c.mpv.mpv_event_property) i64 {
+    if (pc.format != c.mpv.MPV_FORMAT_INT64 or pc.data == null) return 0;
+    return @as(*const i64, @ptrCast(@alignCast(pc.data))).*;
+}
+
+fn eventFlag(pc: *const c.mpv.mpv_event_property) bool {
+    if (pc.format != c.mpv.MPV_FORMAT_FLAG or pc.data == null) return false;
+    return @as(*const c_int, @ptrCast(@alignCast(pc.data))).* != 0;
+}
+
 pub fn updateTorrentBackgroundTasks() void {
     // Republish the "a torrent is waiting to start playing" flag every frame.
     // The stall watchdog wakes the UI while it is set, which is what keeps the
@@ -1164,6 +1228,15 @@ pub fn updateTorrentBackgroundTasks() void {
 
             if (ev.*.event_id == c.mpv.MPV_EVENT_START_FILE) {
                 p.provider = .mpv;
+                // Do not show the previous item's time/size while the new file
+                // is opening, and do not misclassify its first timestamp as a
+                // co-watch rewind.
+                p.last_seen_pos = 0;
+                p.cached_duration = 0;
+                p.cached_paused_for_cache = false;
+                p.cached_video_width = 0;
+                p.cached_video_height = 0;
+                p.cached_sub_text_len = 0;
             } else if (ev.*.event_id == c.mpv.MPV_EVENT_FILE_LOADED) {
                 // Colour metadata is known now, which is the earliest the `auto`
                 // picture preset can decide anything — before this, video-params
@@ -1337,9 +1410,7 @@ pub fn updateTorrentBackgroundTasks() void {
                         // (Rewind detection now lives in the "time-pos" branch so
                         // it fires during silent stretches too.)
                         if (txt.len > 0) {
-                            var pos: f64 = 0;
-                            _ = c.mpv.mpv_get_property(p.mpv_ctx, "time-pos", c.mpv.MPV_FORMAT_DOUBLE, &pos);
-                            p.updateDialogueRing(txt, pos);
+                            p.updateDialogueRing(txt, p.last_seen_pos);
                         }
                     } else {
                         p.cached_sub_text_len = 0;
@@ -1377,6 +1448,24 @@ pub fn updateTorrentBackgroundTasks() void {
                             }
                         }
                     }
+                } else if (std.mem.eql(u8, pname, "duration")) {
+                    p.cached_duration = eventDouble(pc, 0);
+                } else if (std.mem.eql(u8, pname, "volume")) {
+                    p.cached_volume = eventDouble(pc, 100);
+                } else if (std.mem.eql(u8, pname, "speed")) {
+                    p.cached_speed = eventDouble(pc, 1);
+                } else if (std.mem.eql(u8, pname, "mute")) {
+                    p.cached_muted = eventFlag(pc);
+                } else if (std.mem.eql(u8, pname, "paused-for-cache")) {
+                    p.cached_paused_for_cache = eventFlag(pc);
+                } else if (std.mem.eql(u8, pname, "playlist-count")) {
+                    p.cached_playlist_count = eventInt64(pc);
+                } else if (std.mem.eql(u8, pname, "playlist-pos")) {
+                    p.cached_playlist_pos = eventInt64(pc);
+                } else if (std.mem.eql(u8, pname, "dwidth")) {
+                    p.cached_video_width = eventInt64(pc);
+                } else if (std.mem.eql(u8, pname, "dheight")) {
+                    p.cached_video_height = eventInt64(pc);
                 }
             } else if (ev.*.event_id == c.mpv.MPV_EVENT_LOG_MESSAGE) {
                 const log_msg = @as(*c.mpv.mpv_event_log_message, @ptrCast(@alignCast(ev.*.data)));

--- a/src/services/remote.zig
+++ b/src/services/remote.zig
@@ -818,7 +818,7 @@ fn stashRemoteOpen(url: []const u8, kind: []const u8, title: []const u8, art: []
     const sn = @min(subtitle.len, state.app.remote_open_subtitle.len);
     @memcpy(state.app.remote_open_subtitle[0..sn], subtitle[0..sn]);
     state.app.remote_open_subtitle_len = sn;
-    state.app.remote_open_ready = true;
+    state.app.remote_open_ready.store(true, .release);
     state.wakeUi(); // idle UI loop won't run a frame otherwise
 }
 

--- a/src/ui/footer.zig
+++ b/src/ui/footer.zig
@@ -1419,37 +1419,11 @@ pub fn renderLiquidGlassOverlay() void {
         }
     }
 
-    // Query mpv properties — seekbar-critical props every frame, slow props cached.
-    var percent_pos: f64 = 0.0;
-    _ = c.mpv.mpv_get_property(active_p.mpv_ctx, "percent-pos", c.mpv.MPV_FORMAT_DOUBLE, &percent_pos);
-    var time_pos: f64 = 0.0;
-    _ = c.mpv.mpv_get_property(active_p.mpv_ctx, "time-pos", c.mpv.MPV_FORMAT_DOUBLE, &time_pos);
-    var duration: f64 = 0.0;
-    _ = c.mpv.mpv_get_property(active_p.mpv_ctx, "duration", c.mpv.MPV_FORMAT_DOUBLE, &duration);
-
-    const SlowProps = struct {
-        var frame_ctr: u32 = 0;
-        var speed: f64 = 1.0;
-        var is_muted: i64 = 0;
-        var volume: f64 = 100.0;
-        var pl_count: i64 = 0;
-        var pl_pos: i64 = 0;
-        var paused_for_cache: i64 = 0;
-        var last_player_idx: usize = 0;
-    };
-    if (SlowProps.last_player_idx != state.app.active_player_idx) {
-        SlowProps.last_player_idx = state.app.active_player_idx;
-        SlowProps.frame_ctr = 8; // force refresh on next frame
-    }
-    SlowProps.frame_ctr +%= 1;
-    if (SlowProps.frame_ctr % 8 == 0) {
-        _ = c.mpv.mpv_get_property(active_p.mpv_ctx, "speed", c.mpv.MPV_FORMAT_DOUBLE, &SlowProps.speed);
-        _ = c.mpv.mpv_get_property(active_p.mpv_ctx, "mute", c.mpv.MPV_FORMAT_FLAG, &SlowProps.is_muted);
-        _ = c.mpv.mpv_get_property(active_p.mpv_ctx, "volume", c.mpv.MPV_FORMAT_DOUBLE, &SlowProps.volume);
-        _ = c.mpv.mpv_get_property(active_p.mpv_ctx, "playlist-count", c.mpv.MPV_FORMAT_INT64, &SlowProps.pl_count);
-        _ = c.mpv.mpv_get_property(active_p.mpv_ctx, "playlist-pos", c.mpv.MPV_FORMAT_INT64, &SlowProps.pl_pos);
-        _ = c.mpv.mpv_get_property(active_p.mpv_ctx, "paused-for-cache", c.mpv.MPV_FORMAT_FLAG, &SlowProps.paused_for_cache);
-    }
+    // One coherent event-fed snapshot: the render path never blocks on mpv IPC.
+    const playback = active_p.playbackSnapshot();
+    const percent_pos = playback.percent();
+    const time_pos = playback.time_pos;
+    const duration = playback.duration;
 
     // What the bar SAYS it is doing, decided in one tested place. Previously
     // the only signal was the play/pause glyph, so a file still opening and a
@@ -1458,7 +1432,7 @@ pub fn renderLiquidGlassOverlay() void {
     const transport = footer_pure.transportState(
         active_p.is_loading,
         is_paused,
-        SlowProps.paused_for_cache == 1,
+        playback.paused_for_cache,
     );
     const toggle_icon = if (is_paused) icons.tvg.lucide.play else icons.tvg.lucide.pause;
 
@@ -1493,7 +1467,7 @@ pub fn renderLiquidGlassOverlay() void {
         const fit = footer_pure.barLayout(bar_pt);
 
         var wd: dvui.WidgetData = undefined;
-        const has_playlist = SlowProps.pl_count > 1 and fit.skip_buttons;
+        const has_playlist = playback.playlist_count > 1 and fit.skip_buttons;
 
         // ── Previous episode ──
         //
@@ -1526,7 +1500,7 @@ pub fn renderLiquidGlassOverlay() void {
             if (dvui.buttonIcon(@src(), "skip-prev", icons.tvg.lucide.@"skip-back", .{}, .{}, .{
                 .data_out = &wd,
                 .color_fill = transparent,
-                .color_text = if (SlowProps.pl_pos > 0) theme.colors.text_primary else theme.colors.text_tertiary,
+                .color_text = if (playback.playlist_pos > 0) theme.colors.text_primary else theme.colors.text_tertiary,
                 .border = dvui.Rect.all(0),
                 .corner_radius = dvui.Rect.all(theme.radius.sm),
                 .gravity_y = 0.5,
@@ -1666,7 +1640,7 @@ pub fn renderLiquidGlassOverlay() void {
             if (dvui.buttonIcon(@src(), "skip-next", icons.tvg.lucide.@"skip-forward", .{}, .{}, .{
                 .data_out = &wd,
                 .color_fill = transparent,
-                .color_text = if (SlowProps.pl_pos + 1 < SlowProps.pl_count) theme.colors.text_primary else theme.colors.text_tertiary,
+                .color_text = if (playback.playlist_pos + 1 < playback.playlist_count) theme.colors.text_primary else theme.colors.text_tertiary,
                 .border = dvui.Rect.all(0),
                 .corner_radius = dvui.Rect.all(theme.radius.sm),
                 .gravity_y = 0.5,
@@ -1736,16 +1710,16 @@ pub fn renderLiquidGlassOverlay() void {
             // Playlist position / Speed / Loop badges.
             if (has_playlist) {
                 var pl_buf: [16]u8 = undefined;
-                if (std.fmt.bufPrintZ(&pl_buf, " \xC2\xB7 {d}/{d}", .{ SlowProps.pl_pos + 1, SlowProps.pl_count })) |pl_str| {
+                if (std.fmt.bufPrintZ(&pl_buf, " \xC2\xB7 {d}/{d}", .{ playback.playlist_pos + 1, playback.playlist_count })) |pl_str| {
                     _ = dvui.label(@src(), "{s}", .{pl_str}, .{
                         .color_text = theme.colors.text_tertiary,
                         .gravity_y = 0.5,
                     });
                 } else |_| {}
             }
-            if (@abs(SlowProps.speed - 1.0) > 0.01) {
+            if (@abs(playback.speed - 1.0) > 0.01) {
                 var spd_buf: [16]u8 = undefined;
-                if (std.fmt.bufPrintZ(&spd_buf, " \xC2\xB7 {d:.1}\xC3\x97", .{SlowProps.speed})) |sp| {
+                if (std.fmt.bufPrintZ(&spd_buf, " \xC2\xB7 {d:.1}\xC3\x97", .{playback.speed})) |sp| {
                     _ = dvui.label(@src(), "{s}", .{sp}, .{
                         .color_text = theme.colors.text_tertiary,
                         .gravity_y = 0.5,
@@ -1767,8 +1741,8 @@ pub fn renderLiquidGlassOverlay() void {
         // The glyph tracks the LEVEL, not just the mute flag: volume 0, a
         // whisper and full blast all wore the same "volume-2" speaker before,
         // so the icon carried no information unless you were muted.
-        const is_muted = SlowProps.is_muted == 1;
-        const m_icon = switch (footer_pure.volumeLevel(SlowProps.volume, is_muted)) {
+        const is_muted = playback.muted;
+        const m_icon = switch (footer_pure.volumeLevel(playback.volume, is_muted)) {
             .muted => icons.tvg.lucide.@"volume-x",
             .off => icons.tvg.lucide.volume,
             .low => icons.tvg.lucide.@"volume-1",
@@ -1794,67 +1768,66 @@ pub fn renderLiquidGlassOverlay() void {
         // chrome: faint trough, secondary (non-accent) fill. First group to go
         // when the bar narrows; the mute button (the essential control) stays.
         if (fit.volume_slider) {
-        var slider_host = dvui.box(@src(), .{ .dir = .vertical }, .{
-            .min_size_content = .{ .w = 120, .h = 20 },
-            .max_size_content = .{ .w = 120, .h = 20 },
-            .gravity_y = 0.5,
-        });
-        const slider_rect = slider_host.data().contentRectScale().r;
-        const slider_hover = mouseOverRect(slider_rect);
-
-        // Wheel over the volume group = ±5 volume (the scrubber band already
-        // seeks on wheel; the volume slider ignored it).
-        for (dvui.events()) |*ev| {
-            if (ev.handled or ev.evt != .mouse) continue;
-            const me = ev.evt.mouse;
-            if (me.floating_win != dvui.subwindowCurrentId()) continue;
-            switch (me.action) {
-                .wheel_y => |wy| {
-                    if (me.p.x >= slider_rect.x and me.p.x <= slider_rect.x + slider_rect.w and
-                        me.p.y >= slider_rect.y and me.p.y <= slider_rect.y + slider_rect.h)
-                    {
-                        _ = c.mpv.mpv_command_string(active_p.mpv_ctx, if (wy > 0) "add volume 5" else "add volume -5");
-                        SlowProps.frame_ctr = 7; // refresh cached volume next frame
-                        ev.handled = true;
-                    }
-                },
-                else => {},
-            }
-        }
-
-        const vol_f64: f64 = SlowProps.volume;
-        var vol_val: f32 = footer_pure.volumeFraction(vol_f64);
-        if (dvui.slider(@src(), .{ .fraction = &vol_val }, .{
-            .expand = .horizontal,
-            .min_size_content = .{ .w = 120, .h = 4 },
-            .max_size_content = .{ .w = 120, .h = 4 },
-            .color_fill = theme.colors.bg_elevated,
-            .color_text = theme.colors.text_secondary,
-            .corner_radius = dvui.Rect.all(2),
-            .gravity_y = 0.5,
-            .background = true,
-        })) {
-            var set_vol_cmd: [64]u8 = undefined;
-            if (std.fmt.bufPrintZ(&set_vol_cmd, "set volume {d}", .{footer_pure.volumePercent(@as(f64, vol_val) * 100.0)})) |cmd| {
-                _ = c.mpv.mpv_command_string(active_p.mpv_ctx, cmd.ptr);
-            } else |_| {}
-        }
-        slider_host.deinit();
-
-        // Hover-only percentage label.
-        if (slider_hover) {
-            const vol_pct = @as(i32, @intFromFloat(@max(0.0, @min(100.0, vol_f64))));
-            var vol_pct_buf: [8]u8 = undefined;
-            const vol_pct_str = std.fmt.bufPrint(&vol_pct_buf, "{d}%", .{vol_pct}) catch "0%";
-            _ = dvui.label(@src(), "{s}", .{vol_pct_str}, .{
-                .color_text = theme.colors.text_tertiary,
+            var slider_host = dvui.box(@src(), .{ .dir = .vertical }, .{
+                .min_size_content = .{ .w = 120, .h = 20 },
+                .max_size_content = .{ .w = 120, .h = 20 },
                 .gravity_y = 0.5,
-                .margin = .{ .x = 4, .y = 0, .w = 0, .h = 0 },
             });
-        } else {
-            var gap = dvui.box(@src(), .{}, .{ .min_size_content = .{ .w = 4, .h = 0 } });
-            gap.deinit();
-        }
+            const slider_rect = slider_host.data().contentRectScale().r;
+            const slider_hover = mouseOverRect(slider_rect);
+
+            // Wheel over the volume group = ±5 volume (the scrubber band already
+            // seeks on wheel; the volume slider ignored it).
+            for (dvui.events()) |*ev| {
+                if (ev.handled or ev.evt != .mouse) continue;
+                const me = ev.evt.mouse;
+                if (me.floating_win != dvui.subwindowCurrentId()) continue;
+                switch (me.action) {
+                    .wheel_y => |wy| {
+                        if (me.p.x >= slider_rect.x and me.p.x <= slider_rect.x + slider_rect.w and
+                            me.p.y >= slider_rect.y and me.p.y <= slider_rect.y + slider_rect.h)
+                        {
+                            _ = c.mpv.mpv_command_string(active_p.mpv_ctx, if (wy > 0) "add volume 5" else "add volume -5");
+                            ev.handled = true;
+                        }
+                    },
+                    else => {},
+                }
+            }
+
+            const vol_f64: f64 = playback.volume;
+            var vol_val: f32 = footer_pure.volumeFraction(vol_f64);
+            if (dvui.slider(@src(), .{ .fraction = &vol_val }, .{
+                .expand = .horizontal,
+                .min_size_content = .{ .w = 120, .h = 4 },
+                .max_size_content = .{ .w = 120, .h = 4 },
+                .color_fill = theme.colors.bg_elevated,
+                .color_text = theme.colors.text_secondary,
+                .corner_radius = dvui.Rect.all(2),
+                .gravity_y = 0.5,
+                .background = true,
+            })) {
+                var set_vol_cmd: [64]u8 = undefined;
+                if (std.fmt.bufPrintZ(&set_vol_cmd, "set volume {d}", .{footer_pure.volumePercent(@as(f64, vol_val) * 100.0)})) |cmd| {
+                    _ = c.mpv.mpv_command_string(active_p.mpv_ctx, cmd.ptr);
+                } else |_| {}
+            }
+            slider_host.deinit();
+
+            // Hover-only percentage label.
+            if (slider_hover) {
+                const vol_pct = @as(i32, @intFromFloat(@max(0.0, @min(100.0, vol_f64))));
+                var vol_pct_buf: [8]u8 = undefined;
+                const vol_pct_str = std.fmt.bufPrint(&vol_pct_buf, "{d}%", .{vol_pct}) catch "0%";
+                _ = dvui.label(@src(), "{s}", .{vol_pct_str}, .{
+                    .color_text = theme.colors.text_tertiary,
+                    .gravity_y = 0.5,
+                    .margin = .{ .x = 4, .y = 0, .w = 0, .h = 0 },
+                });
+            } else {
+                var gap = dvui.box(@src(), .{}, .{ .min_size_content = .{ .w = 4, .h = 0 } });
+                gap.deinit();
+            }
         } // fit.volume_slider
 
         // ── Spacer pushes pickers + close to the right edge ──
@@ -2198,15 +2171,12 @@ fn renderNowPlayingBar(p: *player.MediaPlayer) void {
     // ── Transport state (cheap, every frame) ──
     // Pause mirrors mpv "pause" via the player worker (cached_paused) — no
     // per-frame mpv IPC read.
-    const is_paused: bool = p.cached_paused;
-    var percent_pos: f64 = 0.0;
-    _ = c.mpv.mpv_get_property(p.mpv_ctx, "percent-pos", c.mpv.MPV_FORMAT_DOUBLE, &percent_pos);
-    var time_pos: f64 = 0.0;
-    _ = c.mpv.mpv_get_property(p.mpv_ctx, "time-pos", c.mpv.MPV_FORMAT_DOUBLE, &time_pos);
-    var duration: f64 = 0.0;
-    _ = c.mpv.mpv_get_property(p.mpv_ctx, "duration", c.mpv.MPV_FORMAT_DOUBLE, &duration);
-    var volume: f64 = 100.0;
-    _ = c.mpv.mpv_get_property(p.mpv_ctx, "volume", c.mpv.MPV_FORMAT_DOUBLE, &volume);
+    const playback = p.playbackSnapshot();
+    const is_paused = playback.paused;
+    const percent_pos = playback.percent();
+    const time_pos = playback.time_pos;
+    const duration = playback.duration;
+    const volume = playback.volume;
 
     // ── Bar panel: bg_surface + 1px top border, ~84px tall (compact) ──
     var bar = dvui.box(@src(), .{ .dir = .vertical }, .{

--- a/src/ui/grid.zig
+++ b/src/ui/grid.zig
@@ -500,28 +500,15 @@ pub fn renderGrid() !void {
                     // 8.3MB per frame and upload all of it to the GPU even
                     // for a 720p file (3.7MB) — a large share of the playback
                     // CPU. The GPU upscales the smaller texture for free.
-                    var vw: i64 = 0;
-                    var vh: i64 = 0;
-                    _ = c.mpv.mpv_get_property(p.mpv_ctx, "dwidth", c.mpv.MPV_FORMAT_INT64, &vw);
-                    _ = c.mpv.mpv_get_property(p.mpv_ctx, "dheight", c.mpv.MPV_FORMAT_INT64, &vh);
-                    var rw: c_int = player.video_w;
-                    var rh: c_int = player.video_h;
-                    if (vw > 0 and vh > 0) {
-                        if (vw <= player.video_w and vh <= player.video_h) {
-                            rw = @intCast(vw);
-                            rh = @intCast(vh);
-                        } else {
-                            // >1080p source: scale down to fit, keep aspect.
-                            const sc = @min(
-                                @as(f64, @floatFromInt(player.video_w)) / @as(f64, @floatFromInt(vw)),
-                                @as(f64, @floatFromInt(player.video_h)) / @as(f64, @floatFromInt(vh)),
-                            );
-                            rw = @intFromFloat(@as(f64, @floatFromInt(vw)) * sc);
-                            rh = @intFromFloat(@as(f64, @floatFromInt(vh)) * sc);
-                        }
-                        rw = @max(2, rw);
-                        rh = @max(2, rh);
-                    }
+                    const playback = p.playbackSnapshot();
+                    const render_size = @import("../player/playback_snapshot_pure.zig").renderSize(
+                        playback.video_width,
+                        playback.video_height,
+                        player.video_w,
+                        player.video_h,
+                    );
+                    const rw: c_int = @intCast(render_size.width);
+                    const rh: c_int = @intCast(render_size.height);
                     const size = [2]c_int{ rw, rh };
                     const img_format = "rgba";
                     const pitch: usize = @as(usize, @intCast(rw)) * 4;

--- a/tests/features/test_player.py
+++ b/tests/features/test_player.py
@@ -210,7 +210,10 @@ def test_tv_calendar_and_hwdec():
         "click-through": "openTvDetailById" in hm,
         "hwdec default on": "hwdec_enabled: bool = true" in st,
         "hwdec migration": '"hwdec2"' in cfg,
-        "adaptive render size": "dwidth" in gr and "textureDestroyLater" in gr,
+        "adaptive render size": ("playbackSnapshot" in gr
+                                 and "renderSize" in gr
+                                 and "textureDestroyLater" in gr
+                                 and 'mpv_get_property(p.mpv_ctx, "dwidth"' not in gr),
     }
     missing = [k for k, v in checks.items() if not v]
     if not missing:

--- a/tests/features/test_stability.py
+++ b/tests/features/test_stability.py
@@ -4,6 +4,43 @@ shared @test decorator, helpers, and run_all()."""
 from .harness import *  # noqa: F401,F403
 import os, sys, subprocess, sqlite3, socket, time, json  # noqa: F401
 
+
+@test("Render hot paths are event-fed; dropped paths are backgrounded", "Stability")
+def test_render_hot_paths_and_drop_ingest():
+    player = _src("src/player/player.zig")
+    footer = _src("src/ui/footer.zig")
+    grid = _src("src/ui/grid.zig")
+    main = _src("src/main.zig")
+    state = _src("src/core/state.zig")
+    drop = _src("src/player/drop_ingest.zig")
+    overlay = _between(footer, "pub fn renderLiquidGlassOverlay", "fn activeMediaPlayer")
+    now_playing = _between(footer, "fn renderNowPlayingBar", "pub fn renderMediaTray")
+    observed = (
+        "duration", "volume", "speed", "mute", "paused-for-cache",
+        "playlist-count", "playlist-pos", "dwidth", "dheight",
+    )
+    checks = {
+        "all UI properties observed": all(f'"{name}"' in player for name in observed),
+        "full controls use snapshot": "playbackSnapshot()" in overlay,
+        "now-playing uses snapshot": "playbackSnapshot()" in now_playing,
+        "critical footer IPC removed": all(
+            f'"{name}"' not in overlay and f'"{name}"' not in now_playing
+            for name in ("percent-pos", "time-pos", "duration", "volume")
+        ),
+        "video sizing uses snapshot": "playbackSnapshot()" in grid and "renderSize(" in grid,
+        "video sizing IPC removed": 'mpv_get_property(p.mpv_ctx, "dwidth"' not in grid,
+        "drop IO runs on worker": "std.Thread.spawn" in drop and "scanDirectory" in drop,
+        "drop scan is bounded": "max_folder_entries" in drop and "workers.isQuitting()" in drop,
+        "old frame scan removed": "scanDirForMedia" not in main and "isDirectory" not in main,
+        "frame mailboxes atomic": "std.atomic.Value(bool)" in state
+                                  and "dropped_file_ready.load(.acquire)" in main
+                                  and "remote_open_ready.load(.acquire)" in main,
+    }
+    missing = [name for name, ok in checks.items() if not ok]
+    if missing:
+        return "fail", "hot-path regression(s): " + ", ".join(missing)
+    return "pass", "mpv render state cached; drop IO bounded+backgrounded; idle locks gated"
+
 @test("Log Severity By Level", "Stability")
 def test_log_severity_by_level():
     # Info/debug/warn logs must not render red: pushLog derives the error flag


### PR DESCRIPTION
## What changed
- replace per-frame libmpv property IPC with one event-fed playback snapshot for transport controls and video sizing
- reset cached playback state between files to avoid stale timelines and false rewind events
- move dropped-folder traversal and M3U parsing off the UI thread with bounded, latest-request-wins, shutdown-aware work
- gate dropped-file and remote-open frame mailboxes with atomics so idle frames avoid mutex traffic
- make M3U entry ownership rollback-safe on allocation failure
- add pure geometry/snapshot tests and strict feature regression guards

## Verification
- clean committed tree: zig build test — 1,718/1,718 passed
- clean committed tree: zig build — passed
- feature suite: 383 passed, 0 product failures; one environment-only Prowlarr reachability failure because the sandbox blocks outbound sockets (10 optional skips, 4 expected warnings)
