### PR TITLE
fix(ui): make default scale adapt to the physical display

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1046,6 +1046,18 @@ pub fn build(b: *std.Build) void {
     });
     test_step.dependOn(&b.addRunArtifact(test_scale_pure).step);
 
+    // Runtime display probe: Linux EDID/sysfs fallback plus the shared Auto
+    // scale seam used by startup and Settings.
+    const test_display_info = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/core/display_info.zig"),
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+        }),
+    });
+    test_step.dependOn(&b.addRunArtifact(test_display_info).step);
+
     // Media file classification: playable vs executable/archive (torrent
     // file auto-selection safety).
     const test_media_ext = b.addTest(.{

--- a/src/core/display_info.zig
+++ b/src/core/display_info.zig
@@ -1,0 +1,179 @@
+//! Physical panel geometry, for picking a sane default UI scale.
+//!
+//! Only Linux needs this. macOS reports a real content scale via
+//! SDL_GetDisplayContentScale, and Windows reports one from its DPI settings —
+//! on both, `scale_pure.deviceScale` trusts that number and never asks here.
+//! Linux is the gap: on a Wayland or X11 session with no `Xft.dpi` set, dvui's
+//! backend has nothing to read and reports exactly 1.0. That is a shrug, not a
+//! measurement, and it made a 2560x1600 190-DPI laptop default to a 0.8 scale.
+//!
+//! The kernel already knows the answer. Every connected output exposes its
+//! current mode and its EDID under /sys/class/drm, which is the same data
+//! `xrandr` prints as "2560x1600 ... 340mm x 220mm".
+
+const std = @import("std");
+const io_global = @import("io_global.zig");
+const scale_pure = @import("scale_pure.zig");
+
+const builtin = @import("builtin");
+const is_linux = builtin.os.tag == .linux;
+
+const DRM_ROOT = "/sys/class/drm";
+
+/// The single runtime seam for Opal's automatic scale. Keeping the platform
+/// probe here means startup and Settings cannot drift into different defaults.
+/// Manual scales never call this function; ui_scale_auto remains their gate.
+pub fn defaultScale(natural_scale: f32) f32 {
+    return scale_pure.deviceScale(natural_scale, probe() orelse .{});
+}
+
+/// Best-effort panel geometry for the display Opal is most likely on, or null
+/// when nothing can be determined (non-Linux, no sysfs, headless, odd driver).
+/// Never returns an error: a missing display probe must degrade to the old
+/// resolution-blind default, not fail startup.
+pub fn probe() ?scale_pure.Display {
+    if (!is_linux) return null;
+
+    var dir = io_global.openDirAbsolute(DRM_ROOT, .{ .iterate = true }) catch return null;
+    defer dir.close(io_global.io());
+
+    // Prefer the built-in panel. A laptop with an external monitor attached
+    // reports both, and the internal one is where a laptop's window opens by
+    // default — and is the one whose DPI is unusual enough to matter.
+    var best: ?scale_pure.Display = null;
+    var best_is_internal = false;
+
+    var it = dir.iterate();
+    while (it.next(io_global.io()) catch null) |entry| {
+        // Connector dirs look like "card2-eDP-2" / "card1-HDMI-A-1"; skip
+        // "version", "renderD128", and the cardN device nodes themselves.
+        if (std.mem.indexOfScalar(u8, entry.name, '-') == null) continue;
+
+        if (!connectorIsConnected(entry.name)) continue;
+        const geom = connectorGeometry(entry.name) orelse continue;
+
+        // "eDP" (embedded DisplayPort) and "LVDS" are internal panels.
+        const internal = std.mem.indexOf(u8, entry.name, "eDP") != null or
+            std.mem.indexOf(u8, entry.name, "LVDS") != null;
+
+        if (best == null or (internal and !best_is_internal)) {
+            best = geom;
+            best_is_internal = internal;
+        }
+    }
+    return best;
+}
+
+fn connectorIsConnected(name: []const u8) bool {
+    var buf: [64]u8 = undefined;
+    const bytes = readConnectorFile(name, "status", &buf) orelse return false;
+    return std.mem.startsWith(u8, bytes, "connected");
+}
+
+fn connectorGeometry(name: []const u8) ?scale_pure.Display {
+    var mode_buf: [256]u8 = undefined;
+    const modes = readConnectorFile(name, "modes", &mode_buf) orelse return null;
+    // First line is the preferred/current mode, e.g. "2560x1600".
+    const first = modes[0 .. std.mem.indexOfScalar(u8, modes, '\n') orelse modes.len];
+    const res = parseMode(first) orelse return null;
+
+    var out = scale_pure.Display{ .px_w = res.w, .px_h = res.h };
+
+    var edid_buf: [512]u8 = undefined;
+    if (readConnectorFile(name, "edid", &edid_buf)) |edid| {
+        if (edidSizeMm(edid)) |mm| {
+            out.mm_w = mm.w;
+            out.mm_h = mm.h;
+        }
+    }
+    return out;
+}
+
+fn readConnectorFile(name: []const u8, leaf: []const u8, buf: []u8) ?[]const u8 {
+    var path_buf: [256]u8 = undefined;
+    const path = std.fmt.bufPrint(&path_buf, DRM_ROOT ++ "/{s}/{s}", .{ name, leaf }) catch return null;
+    const file = io_global.openFileAbsolute(path, .{}) catch return null;
+    defer file.close(io_global.io());
+    const n = file.readPositionalAll(io_global.io(), buf, 0) catch return null;
+    if (n == 0) return null;
+    return buf[0..n];
+}
+
+const Mode = struct { w: f32, h: f32 };
+
+/// "2560x1600" → 2560x1600. Rejects anything else, including the empty string
+/// sysfs returns for a connected-but-unconfigured output.
+pub fn parseMode(line: []const u8) ?Mode {
+    const x = std.mem.indexOfScalar(u8, line, 'x') orelse return null;
+    const w = std.fmt.parseInt(u32, std.mem.trim(u8, line[0..x], " \t\r"), 10) catch return null;
+    const h = std.fmt.parseInt(u32, std.mem.trim(u8, line[x + 1 ..], " \t\r"), 10) catch return null;
+    if (w == 0 or h == 0) return null;
+    return .{ .w = @floatFromInt(w), .h = @floatFromInt(h) };
+}
+
+const SizeMm = struct { w: f32, h: f32 };
+
+/// EDID 1.x basic display parameters: byte 21 is the max horizontal image size
+/// and byte 22 the vertical, both in whole centimetres. Both read 0 for
+/// projectors and for displays that decline to state a size — which is exactly
+/// the case `physicalDpi` must reject rather than guess at.
+pub fn edidSizeMm(edid: []const u8) ?SizeMm {
+    if (edid.len < 23) return null;
+    // Header check — 00 FF FF FF FF FF FF 00. Guards against a driver handing
+    // back a truncated or all-zero blob.
+    const magic = [_]u8{ 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00 };
+    if (!std.mem.eql(u8, edid[0..8], &magic)) return null;
+
+    const cm_w = edid[21];
+    const cm_h = edid[22];
+    if (cm_w == 0 or cm_h == 0) return null;
+    return .{
+        .w = @as(f32, @floatFromInt(cm_w)) * 10.0,
+        .h = @as(f32, @floatFromInt(cm_h)) * 10.0,
+    };
+}
+
+test "probe is analysed and never fails on any host" {
+    // This exists to force semantic analysis of probe() and everything it
+    // calls. The pure parsers below are the interesting logic, but testing only
+    // them left probe() unreferenced — Zig never analysed it, and an invalid
+    // error-set switch inside it passed `zig test` cleanly while breaking the
+    // app build. Result is host-dependent (null off Linux, or on a machine with
+    // no sysfs), so assert nothing about the value.
+    _ = probe();
+}
+
+test "defaultScale is always usable without panel metadata" {
+    const value = defaultScale(1.0);
+    try std.testing.expect(value >= scale_pure.MIN_SCALE);
+    try std.testing.expect(value <= scale_pure.MAX_SCALE);
+}
+
+test "parseMode reads a sysfs modes line" {
+    const m = parseMode("2560x1600").?;
+    try std.testing.expectEqual(@as(f32, 2560), m.w);
+    try std.testing.expectEqual(@as(f32, 1600), m.h);
+    try std.testing.expect(parseMode("") == null);
+    try std.testing.expect(parseMode("garbage") == null);
+    try std.testing.expect(parseMode("0x0") == null);
+}
+
+test "edidSizeMm reads centimetres and rejects unusable blobs" {
+    var edid = [_]u8{0} ** 128;
+    const magic = [_]u8{ 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00 };
+    @memcpy(edid[0..8], &magic);
+    edid[21] = 34; // 34 cm wide
+    edid[22] = 22; // 22 cm tall
+    const mm = edidSizeMm(&edid).?;
+    try std.testing.expectEqual(@as(f32, 340), mm.w);
+    try std.testing.expectEqual(@as(f32, 220), mm.h);
+
+    // A display that states no physical size.
+    edid[21] = 0;
+    try std.testing.expect(edidSizeMm(&edid) == null);
+
+    // Not an EDID at all.
+    var junk = [_]u8{0} ** 128;
+    try std.testing.expect(edidSizeMm(&junk) == null);
+    try std.testing.expect(edidSizeMm("short") == null);
+}

--- a/src/core/scale_pure.zig
+++ b/src/core/scale_pure.zig
@@ -25,15 +25,69 @@ pub fn clampScale(s: f32) f32 {
     return std.math.clamp(s, MIN_SCALE, MAX_SCALE);
 }
 
-/// Device-aware default ui_scale for a display whose DPI content scale is
-/// `natural_scale`. Denser on high-DPI, readable-safe on standard-DPI.
-pub fn deviceScale(natural_scale: f32) f32 {
+/// What the platform could tell us about the physical panel. All fields are 0
+/// when unknown — every consumer treats 0 as "no signal" rather than a value.
+pub const Display = struct {
+    px_w: f32 = 0,
+    px_h: f32 = 0,
+    /// Physical size of the panel. Only Linux fills these in (from EDID);
+    /// macOS and Windows report a trustworthy content scale instead.
+    mm_w: f32 = 0,
+    mm_h: f32 = 0,
+};
+
+/// True physical pixel density, or null when the panel's size is unknown or the
+/// numbers are implausible. Projectors and some EDIDs report a 0 or absurd
+/// physical size, and a bogus DPI here would pick a bogus default scale.
+pub fn physicalDpi(d: Display) ?f32 {
+    if (!std.math.isFinite(d.px_w) or !std.math.isFinite(d.mm_w)) return null;
+    if (d.px_w <= 0 or d.mm_w <= 0) return null;
+    const dpi = d.px_w / (d.mm_w / 25.4);
+    if (!std.math.isFinite(dpi) or dpi < 40 or dpi > 800) return null;
+    return dpi;
+}
+
+/// Device-aware default ui_scale.
+///
+/// `natural_scale` is the OS content scale and is authoritative WHEN THE OS
+/// ACTUALLY REPORTS ONE: macOS and Windows do, and second-guessing them would
+/// double-apply the same correction. Linux frequently does not — on a Wayland
+/// or X11 session with no `Xft.dpi` set, dvui's backend has nothing to read and
+/// falls back to exactly 1.0. That 1.0 is not a measurement, it is a shrug, and
+/// treating it as "standard DPI" is how a 2560x1600 190-DPI laptop panel ended
+/// up defaulting to 0.8 and rendering unreadably small.
+///
+/// So: trust a reported scale above ~1.15, and otherwise fall back to the panel
+/// itself — real DPI when the physical size is known, raw resolution when it is
+/// not.
+pub fn deviceScale(natural_scale: f32, d: Display) f32 {
     // Tiers are ~20% below a 1× baseline — the user runs Opal deliberately
     // compact (see the compact type ramp); the chrome should stay quiet.
-    if (!std.math.isFinite(natural_scale) or natural_scale <= 0) return 0.8;
-    if (natural_scale >= 1.9) return 0.68; // Retina / 200% (macOS, hi-res Win/Linux)
-    if (natural_scale >= 1.4) return 0.72; // ~150% displays
-    if (natural_scale >= 1.15) return 0.76; // ~125% displays
+    if (std.math.isFinite(natural_scale) and natural_scale > 0) {
+        if (natural_scale >= 1.9) return 0.68; // Retina / 200% (macOS, hi-res Win/Linux)
+        if (natural_scale >= 1.4) return 0.72; // ~150% displays
+        if (natural_scale >= 1.15) return 0.76; // ~125% displays
+    }
+
+    // No usable OS scale. Derive density from the panel.
+    if (physicalDpi(d)) |dpi| {
+        if (dpi >= 200) return 1.30; // 4K/5K laptop panels
+        if (dpi >= 170) return 1.20; // ~190 DPI (2560x1600 14", 2880x1800 15")
+        if (dpi >= 140) return 1.00; // 1080p 14" and similar
+        if (dpi >= 115) return 0.90;
+        return 0.80; // ~96 DPI desktop monitor — the original baseline
+    }
+
+    // Physical size unknown: resolution alone. Deliberately gentler than the
+    // DPI ramp, because width cannot distinguish a 14" 2560-wide laptop
+    // (~190 DPI) from a 27" 2560-wide desktop monitor (~109 DPI) — overshooting
+    // the desktop case is worse than undershooting the laptop one, which the
+    // Settings slider fixes in one drag.
+    if (std.math.isFinite(d.px_w)) {
+        if (d.px_w >= 3840) return 1.20;
+        if (d.px_w >= 2560) return 1.10;
+        if (d.px_w >= 1920) return 0.90;
+    }
     return 0.8; // standard DPI — floor for readability at 1 logical px = 1 physical
 }
 
@@ -71,18 +125,55 @@ pub fn isNarrow(rect_w: f32, ui_scale: f32) bool {
     return pt > 1 and pt < NARROW_PT;
 }
 
-test "deviceScale is denser on high-DPI, readable on standard-DPI" {
-    try std.testing.expectEqual(@as(f32, 0.68), deviceScale(2.0)); // Mac Retina
-    try std.testing.expectEqual(@as(f32, 0.68), deviceScale(3.0)); // very high-DPI clamps to densest tier
-    try std.testing.expectEqual(@as(f32, 0.72), deviceScale(1.5)); // 150% Windows
-    try std.testing.expectEqual(@as(f32, 0.76), deviceScale(1.25)); // 125% Windows
-    try std.testing.expectEqual(@as(f32, 0.8), deviceScale(1.0)); // standard DPI Linux/Win
+test "deviceScale trusts a reported OS content scale" {
+    // A display the OS described: the panel numbers must not perturb the tier.
+    const hidpi_panel = Display{ .px_w = 2560, .px_h = 1600, .mm_w = 340, .mm_h = 220 };
+    try std.testing.expectEqual(@as(f32, 0.68), deviceScale(2.0, hidpi_panel)); // Mac Retina
+    try std.testing.expectEqual(@as(f32, 0.68), deviceScale(3.0, .{})); // very high-DPI clamps to densest tier
+    try std.testing.expectEqual(@as(f32, 0.72), deviceScale(1.5, .{})); // 150% Windows
+    try std.testing.expectEqual(@as(f32, 0.76), deviceScale(1.25, .{})); // 125% Windows
 }
 
-test "deviceScale rejects bogus display reports" {
-    try std.testing.expectEqual(@as(f32, 0.8), deviceScale(0));
-    try std.testing.expectEqual(@as(f32, 0.8), deviceScale(-2.0));
-    try std.testing.expectEqual(@as(f32, 0.8), deviceScale(std.math.nan(f32)));
+test "deviceScale falls back to the panel when the OS reports no scale" {
+    // Linux, Wayland, no Xft.dpi → natural_scale is 1.0 as a shrug, not a
+    // measurement. 2560x1600 in 340x220mm is ~191 DPI and must not read as
+    // "standard DPI"; 0.8 here is the bug this fallback exists to fix.
+    const laptop_2560 = Display{ .px_w = 2560, .px_h = 1600, .mm_w = 340, .mm_h = 220 };
+    try std.testing.expectEqual(@as(f32, 1.20), deviceScale(1.0, laptop_2560));
+
+    // Same pixel width, 27" desktop monitor (~109 DPI) — must stay compact.
+    const desktop_27 = Display{ .px_w = 2560, .px_h = 1440, .mm_w = 597, .mm_h = 336 };
+    try std.testing.expectEqual(@as(f32, 0.80), deviceScale(1.0, desktop_27));
+
+    // 4K 15" laptop, ~294 DPI.
+    const laptop_4k = Display{ .px_w = 3840, .px_h = 2160, .mm_w = 332, .mm_h = 187 };
+    try std.testing.expectEqual(@as(f32, 1.30), deviceScale(1.0, laptop_4k));
+
+    // Nothing known at all → the historical default, unchanged.
+    try std.testing.expectEqual(@as(f32, 0.8), deviceScale(1.0, .{}));
+}
+
+test "deviceScale uses resolution when physical size is missing" {
+    try std.testing.expectEqual(@as(f32, 1.20), deviceScale(1.0, .{ .px_w = 3840 }));
+    try std.testing.expectEqual(@as(f32, 1.10), deviceScale(1.0, .{ .px_w = 2560 }));
+    try std.testing.expectEqual(@as(f32, 0.90), deviceScale(1.0, .{ .px_w = 1920 }));
+    try std.testing.expectEqual(@as(f32, 0.80), deviceScale(1.0, .{ .px_w = 1366 }));
+}
+
+test "physicalDpi rejects implausible panel geometry" {
+    try std.testing.expect(physicalDpi(.{ .px_w = 2560, .mm_w = 340 }) != null);
+    try std.testing.expect(physicalDpi(.{ .px_w = 2560, .mm_w = 0 }) == null); // EDID gave no size
+    try std.testing.expect(physicalDpi(.{ .px_w = 0, .mm_w = 340 }) == null);
+    // A projector reporting a 4m-wide "panel" — ~16 DPI, below the floor.
+    try std.testing.expect(physicalDpi(.{ .px_w = 2560, .mm_w = 4000 }) == null);
+}
+
+test "deviceScale tolerates a garbage natural scale" {
+    try std.testing.expectEqual(@as(f32, 0.8), deviceScale(0, .{}));
+    try std.testing.expectEqual(@as(f32, 0.8), deviceScale(-1, .{}));
+    try std.testing.expectEqual(@as(f32, 0.8), deviceScale(std.math.nan(f32), .{}));
+    // …and still consults the panel in that case.
+    try std.testing.expectEqual(@as(f32, 1.20), deviceScale(std.math.nan(f32), .{ .px_w = 2560, .mm_w = 340 }));
 }
 
 test "clampScale keeps values in the usable band" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -776,7 +776,10 @@ fn appFrame() !dvui.App.Result {
     if (!device_scale_applied and state.app.config_loaded.load(.acquire)) {
         device_scale_applied = true;
         if (state.app.ui_scale_auto) {
-            state.app.ui_scale = @import("core/scale_pure.zig").deviceScale(dvui.windowNaturalScale());
+            // The panel probe is Linux-only; macOS and Windows keep using the
+            // authoritative OS content scale. This runs once after config load
+            // so the first layout is stable and a manual choice still wins.
+            state.app.ui_scale = @import("core/display_info.zig").defaultScale(dvui.windowNaturalScale());
         }
     }
 

--- a/src/ui/settings.zig
+++ b/src/ui/settings.zig
@@ -1064,9 +1064,9 @@ fn renderGeneralTab() void {
     // ── Interface ── (whitespace-separated, no card chrome)
     sectionHeader("Interface", "Customize how Opal looks and feels", 10, @src());
 
-    // UI Scale — "Auto" derives a compact, DPI-aware scale from the display
-    // each launch (see scale_pure.deviceScale); the manual steps pin a fixed
-    // value. Sub-1× steps let users go denser than the compact type ramp alone.
+    // UI Scale — "Auto" derives a density-aware scale from the OS and, when
+    // Linux reports only a placeholder 1×, the panel's EDID. Manual steps pin
+    // a fixed value. Sub-1× steps keep a compact option available.
     settingRow("UI Scale", 100, @src());
     {
         const scales = [_]f32{ 0.6, 0.7, 0.8, 0.9, 1.0, 1.2, 1.4, 1.6, 2.0 };
@@ -1084,7 +1084,7 @@ fn renderGeneralTab() void {
         if (components.segment(@src(), &scale_labels, sel)) |clicked| {
             if (clicked == 0) {
                 state.app.ui_scale_auto = true;
-                state.app.ui_scale = @import("../core/scale_pure.zig").deviceScale(dvui.windowNaturalScale());
+                state.app.ui_scale = @import("../core/display_info.zig").defaultScale(dvui.windowNaturalScale());
             } else {
                 state.app.ui_scale_auto = false;
                 state.app.ui_scale = scales[clicked - 1];

--- a/tests/features/test_page_shell2.py
+++ b/tests/features/test_page_shell2.py
@@ -488,3 +488,38 @@ def test_breakpoints_in_points():
     return "pass", ("compact/narrow breakpoints convert scaled layout units to "
                     "on-screen points via scale_pure, so the right-hand nav "
                     "actions stay reachable on narrow windows")
+
+
+@test("Auto UI scale adapts to the physical display by default", "Page Shell")
+def test_adaptive_default_scale():
+    sp = _src("src/core/scale_pure.zig")
+    di = _src("src/core/display_info.zig")
+    st = _src("src/core/state.zig")
+    mn = _src("src/main.zig")
+    settings = _src("src/ui/settings.zig")
+    bz = _src("build.zig")
+    checks = {
+        "auto is the default": "ui_scale_auto: bool = true" in st,
+        "panel model includes pixels and millimetres": all(
+            field in sp for field in ("px_w", "px_h", "mm_w", "mm_h")
+        ),
+        "physical DPI validated": "pub fn physicalDpi(" in sp
+                                  and "dpi < 40" in sp and "dpi > 800" in sp,
+        "screen classes covered": all(label in sp for label in (
+            "laptop_2560", "desktop_27", "laptop_4k",
+            "resolution when physical size is missing",
+        )),
+        "Linux reads connected display EDID": all(token in di for token in (
+            'DRM_ROOT = "/sys/class/drm"', '"status"', '"modes"', '"edid"',
+        )),
+        "one shared runtime seam": "pub fn defaultScale(" in di
+                                   and 'display_info.zig").defaultScale' in mn
+                                   and 'display_info.zig").defaultScale' in settings,
+        "manual scale remains a hard override": "if (state.app.ui_scale_auto)" in mn
+                                                and "state.app.ui_scale_auto = false" in settings,
+        "probe registered in unit suite": "test_display_info" in bz,
+    }
+    missing = [name for name, ok in checks.items() if not ok]
+    if missing:
+        return "fail", "adaptive-scale regression(s): " + ", ".join(missing)
+    return "pass", "Auto defaults on; OS scale + validated EDID/resolution fallbacks; manual override preserved"


### PR DESCRIPTION
## Summary
- keep Auto as the default and apply it once after persisted config loads
- trust OS content scaling on macOS/Windows; on Linux, fall back to connected-panel EDID DPI and conservative resolution tiers
- share one runtime scaling seam between startup and Settings while preserving manual overrides
- add pure screen-class coverage and a strict feature regression guard

## Verification
- zig build test
- zig build
- focused adaptive-scale feature guard: pass
- comprehensive feature suite: 368 passed, 9 skipped, 3 warnings; 19 environment-only failures from the isolated checkout being denied access to the shared runtime DB, plus the sandboxed live Prowlarr probe

The automatic value is computed once rather than during rendering, avoiding scale-driven layout instability.