### PR TITLE
fix(security): single-source app identity, race-free media opens, Watching redesign

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -83,6 +83,12 @@ Linked at build time — failures here usually mean a missing system package:
 
 Build options: `-Dheadless`, `-fsys=sdl2`.
 
+Development builds report the exact version declared in `build.zig.zon`, the
+same value used by release builds. They do not add an implicit `-dev` suffix;
+use the commit hash alongside the reported version when identifying a local
+build. Application user agents and API version fields must come from
+`src/core/app_meta.zig`, never from release-looking string literals.
+
 The companion **web UI** lives in `web/` as an independent Zig project (`zig build dev`, serves on `:3000`, talks to the remote JSON API on `:41595`).
 
 ---

--- a/build.zig
+++ b/build.zig
@@ -29,6 +29,7 @@ pub fn build(b: *std.Build) void {
 
     build_options.addOption([]const u8, "tmdb_default_token", embeddedKey(b, &.{ "OPAL_TMDB_TOKEN", "TMDB_API_TOKEN" }));
     build_options.addOption([]const u8, "omdb_default_key", embeddedKey(b, &.{ "OPAL_OMDB_KEY", "OMDB_API_KEY" }));
+    const build_options_module = build_options.createModule();
 
     const exe = b.addExecutable(.{
         .name = "opal",
@@ -166,7 +167,7 @@ pub fn build(b: *std.Build) void {
     }
 
     // Expose -Dheadless to the app code via @import("build_options").
-    exe.root_module.addImport("build_options", build_options.createModule());
+    exe.root_module.addImport("build_options", build_options_module);
 
     // Fetch and bind TVG Icons library
     const icons_dep = b.dependency("icons", .{
@@ -1182,6 +1183,48 @@ pub fn build(b: *std.Build) void {
         }),
     });
     test_step.dependOn(&b.addRunArtifact(test_remote_stream_pure).step);
+
+    // Download-root confinement: component-by-component no-follow opens and
+    // regular-file enforcement for stream/subtitle/transcode endpoints.
+    const test_remote_stream_path = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/services/remote_stream_path.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    test_step.dependOn(&b.addRunArtifact(test_remote_stream_path).step);
+
+    // Canonical application version and release-derived user-agent strings.
+    const test_app_meta = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/core/app_meta.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    test_app_meta.root_module.addImport("build_options", build_options_module);
+    test_step.dependOn(&b.addRunArtifact(test_app_meta).step);
+
+    const test_display_name = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/core/display_name_pure.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    test_step.dependOn(&b.addRunArtifact(test_display_name).step);
+
+    // /api/host must expose the same version injected from build.zig.zon.
+    const test_remote_host = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/services/remote_host_pure.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    test_remote_host.root_module.addImport("build_options", build_options_module);
+    test_step.dependOn(&b.addRunArtifact(test_remote_host).step);
 
     // TV calendar: air-date math, countdown labels, TMDB next-episode parse,
     // EZTV availability extraction.

--- a/src/core/app_meta.zig
+++ b/src/core/app_meta.zig
@@ -1,0 +1,13 @@
+//! Canonical application identity derived from build metadata.
+
+pub const version: []const u8 = @import("build_options").app_version;
+pub const user_agent: []const u8 = "Opal/" ++ version;
+pub const user_agent_with_url: []const u8 = user_agent ++ " (+https://github.com/debpalash/Opal)";
+pub const browser_user_agent: []const u8 = "Mozilla/5.0 (X11; Linux x86_64) " ++ user_agent;
+
+test "application identity uses the injected version" {
+    const std = @import("std");
+    try std.testing.expect(version.len > 0);
+    try std.testing.expectEqualStrings("Opal/" ++ version, user_agent);
+    try std.testing.expect(std.mem.endsWith(u8, browser_user_agent, user_agent));
+}

--- a/src/core/display_name_pure.zig
+++ b/src/core/display_name_pure.zig
@@ -1,0 +1,41 @@
+//! User-facing names for local media paths and release-style filenames.
+
+const std = @import("std");
+
+/// Basename, remove a short extension, replace separators used as spaces, and
+/// collapse whitespace. Returns `raw` if cleanup would produce an empty name.
+pub fn clean(out: []u8, raw: []const u8) []const u8 {
+    if (out.len == 0) return raw;
+
+    var basename_start: usize = 0;
+    for (raw, 0..) |ch, i| {
+        if (ch == '/' or ch == '\\') basename_start = i + 1;
+    }
+    const basename = raw[basename_start..];
+
+    var name_end = basename.len;
+    if (std.mem.lastIndexOfScalar(u8, basename, '.')) |dot| {
+        if (basename.len - dot <= 6) name_end = dot;
+    }
+
+    var written: usize = 0;
+    for (basename[0..name_end]) |ch| {
+        if (written >= out.len) break;
+        const display_ch: u8 = if (ch == '.' or ch == '_') ' ' else ch;
+        if (display_ch == ' ' and (written == 0 or out[written - 1] == ' ')) continue;
+        out[written] = display_ch;
+        written += 1;
+    }
+    while (written > 0 and out[written - 1] == ' ') written -= 1;
+    return if (written > 0) out[0..written] else raw;
+}
+
+test "local paths become readable media titles" {
+    var out: [128]u8 = undefined;
+    try std.testing.expectEqualStrings(
+        "Making music symbol with dust 202608071750",
+        clean(&out, "/Users/me/Downloads/Making_music_symbol_with_dust_202608071750.mp4"),
+    );
+    try std.testing.expectEqualStrings("Dune Part Two", clean(&out, "Dune.Part_Two.mkv"));
+    try std.testing.expectEqualStrings("Episode", clean(&out, "C:\\Media\\Episode.webm"));
+}

--- a/src/core/io_global.zig
+++ b/src/core/io_global.zig
@@ -737,6 +737,16 @@ pub const Child = struct {
         }
     }
 
+    /// Transfer ownership of a piped stdin handle out of the child wrapper.
+    /// The caller must close the returned file. Clearing both copies prevents
+    /// wait()/kill() from closing a descriptor used by a concurrent feeder.
+    pub fn takeStdin(self: *Child) ?std.Io.File {
+        const pipe = self.stdin orelse return null;
+        self.stdin = null;
+        if (self.real) |*r| r.stdin = null;
+        return pipe;
+    }
+
     pub fn spawnAndWait(self: *Child) !Term {
         try self.spawn();
         return self.wait();

--- a/src/player/subtitles.zig
+++ b/src/player/subtitles.zig
@@ -188,7 +188,7 @@ fn urlEncode(input: []const u8, out: *[512]u8) []const u8 {
 fn httpGet(url_str: []const u8, extra_headers: []const std.http.Header, response_buf: []u8) ![]const u8 {
     const alloc = @import("../core/alloc.zig").allocator;
     const io = @import("../core/io_global.zig");
-    var ua: []const u8 = "Opal/1.0";
+    var ua: []const u8 = @import("../core/app_meta.zig").user_agent;
     for (extra_headers) |h| {
         if (std.ascii.eqlIgnoreCase(h.name, "User-Agent")) ua = h.value;
     }
@@ -225,7 +225,7 @@ fn searchThread(engine: *SubtitleEngine) void {
     
     // HTTP GET with User-Agent header
     const headers = [_]std.http.Header{
-        .{ .name = "User-Agent", .value = "Opal/1.0" },
+        .{ .name = "User-Agent", .value = @import("../core/app_meta.zig").user_agent },
     };
     
     var response_buf: [128 * 1024]u8 = undefined;
@@ -304,7 +304,7 @@ fn gestdownAppend(engine: *SubtitleEngine, base: usize) usize {
     const p = sp.parse(engine.query_buf[0..engine.query_len], &q_buf, &show_buf);
     if (!p.is_tv or p.show.len == 0) return base;
 
-    const headers = [_]std.http.Header{.{ .name = "User-Agent", .value = "Opal/1.0" }};
+    const headers = [_]std.http.Header{.{ .name = "User-Agent", .value = @import("../core/app_meta.zig").user_agent }};
     var enc: [512]u8 = undefined;
 
     // 1) show search → first show id (a UUID)
@@ -424,7 +424,7 @@ fn stremioOsAppend(engine: *SubtitleEngine, base: usize) usize {
     else
         std.fmt.bufPrint(&url3, "https://opensubtitles-v3.strem.io/subtitles/movie/{s}.json", .{imdb_id}) catch return base;
 
-    const headers = [_]std.http.Header{.{ .name = "User-Agent", .value = "Opal/1.0" }};
+    const headers = [_]std.http.Header{.{ .name = "User-Agent", .value = @import("../core/app_meta.zig").user_agent }};
     @import("../core/rate_limit.zig").acquire("stremio", 1.0); // third-party addon — be gentle
     const json = httpGet(endpoint, &headers, buf) catch return base;
 
@@ -488,7 +488,7 @@ fn downloadThread(engine: *SubtitleEngine) void {
     
     // Download the subtitle file via HTTP
     const headers = [_]std.http.Header{
-        .{ .name = "User-Agent", .value = "Opal/1.0" },
+        .{ .name = "User-Agent", .value = @import("../core/app_meta.zig").user_agent },
     };
     
     const alloc = @import("../core/alloc.zig").allocator;

--- a/src/services/comics.zig
+++ b/src/services/comics.zig
@@ -575,7 +575,7 @@ fn fetchComicThread(gen: u32) void {
 fn fetchUrl(url: []const u8, dst: []u8) usize {
     // Per-host UA: MangaDex 400s a spoofed browser UA (see pure.userAgentFor).
     var ua_buf: [200]u8 = undefined;
-    const ua = std.fmt.bufPrint(&ua_buf, "User-Agent: {s}", .{pure.userAgentFor(url)}) catch return 0;
+    const ua = std.fmt.bufPrint(&ua_buf, "User-Agent: {s}", .{pure.userAgentFor(url, @import("../core/app_meta.zig").user_agent_with_url)}) catch return 0;
     const argv = [_][]const u8{
         "curl",       "-sL",
         "-H",         ua,
@@ -960,7 +960,7 @@ fn loadThemesiaPages(detail_url: []const u8) bool {
 /// which WordPress only answers to an `X-Requested-With: XMLHttpRequest` POST.
 fn fetchPost(url: []const u8, body: []const u8, dst: []u8) usize {
     var ua_buf: [200]u8 = undefined;
-    const ua = std.fmt.bufPrint(&ua_buf, "User-Agent: {s}", .{pure.userAgentFor(url)}) catch return 0;
+    const ua = std.fmt.bufPrint(&ua_buf, "User-Agent: {s}", .{pure.userAgentFor(url, @import("../core/app_meta.zig").user_agent_with_url)}) catch return 0;
     const argv = [_][]const u8{
         "curl",       "-sL",
         "-H",         ua,
@@ -1364,7 +1364,7 @@ fn downloadSinglePage(i: usize, gen: u32) void {
     // but routing through the one selector keeps every comics fetch consistent
     // and means a future MangaDex host can't silently regress to a 400.
     var ua_buf: [200]u8 = undefined;
-    const ua = std.fmt.bufPrint(&ua_buf, "User-Agent: {s}", .{pure.userAgentFor(url)}) catch return;
+    const ua = std.fmt.bufPrint(&ua_buf, "User-Agent: {s}", .{pure.userAgentFor(url, @import("../core/app_meta.zig").user_agent_with_url)}) catch return;
 
     // OPDS-PSE page streams (Komga/Kavita) require HTTP Basic auth on EVERY page
     // fetch. loadPseBook stashes the full "Authorization: Basic …" line here; it
@@ -2764,7 +2764,7 @@ fn coverWorker(idx: usize) void {
     // browser UA — every cover would render as a blank placeholder. The scrapers'
     // blogspot CDN still gets the browser UA. See pure.userAgentFor.
     var ua_buf: [200]u8 = undefined;
-    const ua = std.fmt.bufPrint(&ua_buf, "User-Agent: {s}", .{pure.userAgentFor(url)}) catch return;
+    const ua = std.fmt.bufPrint(&ua_buf, "User-Agent: {s}", .{pure.userAgentFor(url, @import("../core/app_meta.zig").user_agent_with_url)}) catch return;
     const argv = [_][]const u8{
         "curl",       "-sL",
         "-H",         ua,

--- a/src/services/comics_pure.zig
+++ b/src/services/comics_pure.zig
@@ -296,12 +296,11 @@ pub const MD_SCHEME = "mangadex:";
 // So the UA is per-HOST, not global: keep the browser UA for the HTML scrapers,
 // send an identifying UA to MangaDex (which is also what its docs ask for).
 pub const UA_BROWSER = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
-pub const UA_OPAL = "Opal/1.0 (+https://github.com/debpalash/Opal)";
 
 /// The User-Agent to send for `url`. MangaDex hosts get the identifying UA; every
 /// other host keeps the browser UA the scrapers rely on.
-pub fn userAgentFor(url: []const u8) []const u8 {
-    if (std.mem.indexOf(u8, url, "mangadex.") != null) return UA_OPAL;
+pub fn userAgentFor(url: []const u8, opal_user_agent: []const u8) []const u8 {
+    if (std.mem.indexOf(u8, url, "mangadex.") != null) return opal_user_agent;
     return UA_BROWSER;
 }
 
@@ -601,18 +600,19 @@ test "regression: MangaDex hosts get the API UA, scrapers keep the browser UA" {
     // bot), so search returned nothing and every cover was blank. Verified live.
     var buf: [768]u8 = undefined;
     const id = "801513ba-a712-498c-8f57-cae55b38cc92";
+    const app_ua = "Opal/test-version (+https://github.com/debpalash/Opal)";
 
-    try std.testing.expectEqualStrings(UA_OPAL, userAgentFor(buildSearchUrl(&buf, "x", 20, 0).?));
-    try std.testing.expectEqualStrings(UA_OPAL, userAgentFor(buildFeedUrl(&buf, id, 1, 0).?));
-    try std.testing.expectEqualStrings(UA_OPAL, userAgentFor(buildAtHomeUrl(&buf, id).?));
-    try std.testing.expectEqualStrings(UA_OPAL, userAgentFor(buildCoverUrl(&buf, id, "c.jpg").?));
+    try std.testing.expectEqualStrings(app_ua, userAgentFor(buildSearchUrl(&buf, "x", 20, 0).?, app_ua));
+    try std.testing.expectEqualStrings(app_ua, userAgentFor(buildFeedUrl(&buf, id, 1, 0).?, app_ua));
+    try std.testing.expectEqualStrings(app_ua, userAgentFor(buildAtHomeUrl(&buf, id).?, app_ua));
+    try std.testing.expectEqualStrings(app_ua, userAgentFor(buildCoverUrl(&buf, id, "c.jpg").?, app_ua));
     // The page CDN is a different host (…mangadex.network) — it accepts either,
     // but it is still MangaDex, so it gets the honest UA too.
-    try std.testing.expectEqualStrings(UA_OPAL, userAgentFor("https://cmdxd98sb0x3yprd.mangadex.network/data/h/1.png"));
+    try std.testing.expectEqualStrings(app_ua, userAgentFor("https://cmdxd98sb0x3yprd.mangadex.network/data/h/1.png", app_ua));
     // Everything else — the HTML scrapers and their blogspot CDN — MUST keep the
     // browser UA (they rely on it to get past Cloudflare).
-    try std.testing.expectEqualStrings(UA_BROWSER, userAgentFor("https://readallcomics.com/invincible-001/"));
-    try std.testing.expectEqualStrings(UA_BROWSER, userAgentFor("https://1.bp.blogspot.com/x.jpg"));
+    try std.testing.expectEqualStrings(UA_BROWSER, userAgentFor("https://readallcomics.com/invincible-001/", app_ua));
+    try std.testing.expectEqualStrings(UA_BROWSER, userAgentFor("https://1.bp.blogspot.com/x.jpg", app_ua));
 }
 
 test "buildSearchUrl: empty query yields no request" {

--- a/src/services/remote.zig
+++ b/src/services/remote.zig
@@ -1124,9 +1124,11 @@ fn handleApi(stream: std.Io.net.Stream, api_path: []const u8, query: []const u8,
     // vs companion (control the desktop player) behavior.
     if (std.mem.eql(u8, api_path, "/host")) {
         var jb: [128]u8 = undefined;
-        const j = std.fmt.bufPrint(&jb, "{{\"headless\":{s},\"version\":\"0.1.2\"}}", .{
-            if (state.app.is_headless) "true" else "false",
-        }) catch return;
+        const j = @import("remote_host_pure.zig").build(
+            &jb,
+            state.app.is_headless,
+            @import("../core/app_meta.zig").version,
+        ) orelse return;
         sendJson(stream, j);
         return;
     }

--- a/src/services/remote_host_pure.zig
+++ b/src/services/remote_host_pure.zig
@@ -1,0 +1,19 @@
+//! Host-capability response construction, separated for behavior-level tests.
+
+const std = @import("std");
+
+pub fn build(out: []u8, headless: bool, version: []const u8) ?[]const u8 {
+    return std.fmt.bufPrint(out, "{{\"headless\":{s},\"version\":\"{s}\"}}", .{
+        if (headless) "true" else "false",
+        version,
+    }) catch null;
+}
+
+test "host response reports the canonical application version" {
+    const canonical_version = @import("build_options").app_version;
+    var actual_buf: [128]u8 = undefined;
+    const actual = build(&actual_buf, true, canonical_version) orelse return error.TestUnexpectedResult;
+    var expected_buf: [128]u8 = undefined;
+    const expected = try std.fmt.bufPrint(&expected_buf, "{{\"headless\":true,\"version\":\"{s}\"}}", .{canonical_version});
+    try std.testing.expectEqualStrings(expected, actual);
+}

--- a/src/services/remote_stream.zig
+++ b/src/services/remote_stream.zig
@@ -12,6 +12,7 @@ const std = @import("std");
 const state = @import("../core/state.zig");
 const io_g = @import("../core/io_global.zig");
 const pure = @import("remote_stream_pure.zig");
+const secure_path = @import("remote_stream_path.zig");
 const alloc = @import("../core/alloc.zig").allocator;
 
 const CHUNK = 256 * 1024;
@@ -30,25 +31,32 @@ fn downloadsRoot(buf: []u8) []const u8 {
     return @import("../core/paths.zig").defaultSavePath(buf);
 }
 
-fn resolveUnder(root: []const u8, rel: []const u8, buf: []u8) ?[]const u8 {
-    if (!pure.safeRelPath(rel)) return null;
-    return std.fmt.bufPrint(buf, "{s}/{s}", .{ root, rel }) catch null;
+/// Open one regular file beneath the configured downloads directory without
+/// ever resolving a request-controlled pathname from the process cwd.
+fn openServedFile(rel: []const u8) ?std.Io.File {
+    var root_buf: [512]u8 = undefined;
+    // The configured root is trusted and may itself intentionally be a
+    // symlink (for example Downloads on another volume). Once opened, its
+    // directory handle is the immutable containment anchor.
+    var root = io_g.cwdOpenDir(downloadsRoot(&root_buf), .{}) catch return null;
+    defer root.close(io_g.io());
+    return secure_path.openRegularAt(io_g.io(), root, rel) catch |err| {
+        switch (err) {
+            error.UnsafePath, error.SymLinkLoop, error.UnsupportedFileType, error.AccessDenied, error.NotDir => @import("../core/logs.zig").pushLog("warn", "remote", "rejected unsafe download file request", false),
+            else => {},
+        }
+        return null;
+    };
 }
 
 /// GET /stream?file=<rel>[&t=token] — Range-aware file streaming from the
 /// downloads dir. Works mid-download (reads whatever bytes exist; the
 /// torrent path already prioritizes sequential pieces for streaming).
 pub fn handleStream(stream: std.Io.net.Stream, request: []const u8, rel: []const u8) void {
-    var root_buf: [512]u8 = undefined;
-    var path_buf: [1600]u8 = undefined;
-    const path = resolveUnder(downloadsRoot(&root_buf), rel, &path_buf) orelse return send404(stream);
-
-    const st = io_g.cwdStatFile(path) catch return send404(stream);
-    const size: u64 = st.size;
-
-    const file = io_g.cwdOpenFile(path, .{}) catch return send404(stream);
-    var fh = file;
+    var fh = openServedFile(rel) orelse return send404(stream);
     defer fh.close(io_g.io());
+    const st = fh.stat(io_g.io()) catch return send404(stream);
+    const size: u64 = st.size;
 
     // Range header (if any). Absent/garbage → whole file, 200.
     var range: ?pure.Range = null;
@@ -81,12 +89,14 @@ pub fn handleStream(stream: std.Io.net.Stream, request: []const u8, rel: []const
 
 /// GET /vtt?file=<rel .srt/.vtt>[&t=] — subtitle sidecar as WebVTT.
 pub fn handleVtt(stream: std.Io.net.Stream, rel: []const u8) void {
-    var root_buf: [512]u8 = undefined;
-    var path_buf: [1600]u8 = undefined;
-    const path = resolveUnder(downloadsRoot(&root_buf), rel, &path_buf) orelse return send404(stream);
-
-    const raw = io_g.cwdReadFileAlloc(path, alloc, 2 * 1024 * 1024) catch return send404(stream);
+    var file = openServedFile(rel) orelse return send404(stream);
+    defer file.close(io_g.io());
+    const size = file.length(io_g.io()) catch return send404(stream);
+    if (size > 2 * 1024 * 1024) return send404(stream);
+    const raw = alloc.alloc(u8, @intCast(size)) catch return send404(stream);
     defer alloc.free(raw);
+    const read = file.readPositionalAll(io_g.io(), raw, 0) catch return send404(stream);
+    if (read != raw.len) return send404(stream);
 
     var body: []const u8 = raw;
     var converted: ?[]u8 = null;
@@ -436,6 +446,24 @@ const TRANSCODE_CHUNK = 16 * 1024;
 /// closed tab does not leave an encoder running for minutes.
 const TRANSCODE_SEND_TIMEOUT_S: i32 = 20;
 
+const TranscodeInput = struct {
+    source: std.Io.File,
+    pipe: std.Io.File,
+
+    fn pump(self: *TranscodeInput) void {
+        defer self.source.close(io_g.io());
+        defer self.pipe.close(io_g.io());
+        var buf: [64 * 1024]u8 = undefined;
+        var offset: u64 = 0;
+        while (true) {
+            const n = self.source.readPositionalAll(io_g.io(), &buf, offset) catch return;
+            if (n == 0) return;
+            io_g.writeAll(self.pipe, buf[0..n]) catch return;
+            offset += n;
+        }
+    }
+};
+
 /// `/transcode?file=<rel>&t=<token>[&start=<seconds>]`
 ///
 /// Cleanup note, because three obvious fixes here were wrong.
@@ -461,25 +489,25 @@ pub fn handleTranscode(stream: std.Io.net.Stream, rel: []const u8, start_s: u32)
         return;
     }
 
-    var root_buf: [512]u8 = undefined;
-    var path_buf: [1600]u8 = undefined;
-    const path = resolveUnder(downloadsRoot(&root_buf), rel, &path_buf) orelse return send404(stream);
-    _ = io_g.cwdStatFile(path) catch return send404(stream);
+    var source = openServedFile(rel) orelse return send404(stream);
+    var source_owned = true;
+    defer if (source_owned) source.close(io_g.io());
 
     var ss_buf: [16]u8 = undefined;
     const ss = std.fmt.bufPrint(&ss_buf, "{d}", .{start_s}) catch "0";
 
-    // -ss BEFORE -i is the fast (keyframe) seek; exact-frame seeking would
-    // decode everything up to the offset, which defeats the point.
+    // Feed the already-opened file through stdin. Passing its pathname would
+    // let an attacker swap in a symlink between validation and ffmpeg's open.
+    // -ss follows -i because a pipe is intentionally non-seekable.
     var child = io_g.Child.init(&.{
         ffmpegPath(),
         "-hide_banner",
         "-loglevel",
         "error",
+        "-i",
+        "pipe:0",
         "-ss",
         ss,
-        "-i",
-        path,
         "-c:v",
         "libx264",
         "-preset",
@@ -496,10 +524,24 @@ pub fn handleTranscode(stream: std.Io.net.Stream, rel: []const u8, start_s: u32)
         "mp4",
         "pipe:1",
     }, alloc);
-    child.stdin_behavior = .Ignore;
+    child.stdin_behavior = .Pipe;
     child.stdout_behavior = .Pipe;
     child.stderr_behavior = .Ignore;
     child.spawn() catch return send404(stream);
+
+    const child_stdin = child.takeStdin() orelse {
+        _ = child.kill() catch {};
+        return send404(stream);
+    };
+    var input = TranscodeInput{ .source = source, .pipe = child_stdin };
+    source_owned = false;
+    const input_thread = std.Thread.spawn(.{}, TranscodeInput.pump, .{&input}) catch {
+        input.pipe.close(io_g.io());
+        input.source.close(io_g.io());
+        _ = child.kill() catch {};
+        return send404(stream);
+    };
+    defer input_thread.join();
 
     // No Content-Length: the length is unknowable until the encode finishes.
     // Connection: close so the client treats EOF as end-of-stream.

--- a/src/services/remote_stream_path.zig
+++ b/src/services/remote_stream_path.zig
@@ -1,0 +1,115 @@
+//! Race-resistant file opens for browser media routes.
+//!
+//! Security depends on walking from an already-open download-root directory
+//! and refusing symlinks for every component.  Joining strings, canonicalizing
+//! a pathname, and opening it afterwards would leave a check/open race.
+
+const std = @import("std");
+const pure = @import("remote_stream_pure.zig");
+
+pub const OpenError = std.Io.Dir.OpenError || std.Io.File.OpenError || std.Io.File.StatError || error{
+    UnsafePath,
+    UnsupportedFileType,
+};
+
+/// Open `rel` below `root`. `root` remains owned by the caller; the returned
+/// file is owned by the caller. Every intermediate directory is opened without
+/// following symlinks, so renames after an open cannot redirect the walk.
+pub fn openRegularAt(io: std.Io, root: std.Io.Dir, rel: []const u8) OpenError!std.Io.File {
+    if (!pure.safeRelPath(rel)) return error.UnsafePath;
+
+    var current = root;
+    var owns_current = false;
+    defer if (owns_current) current.close(io);
+
+    var components = std.mem.splitScalar(u8, rel, '/');
+    var component = components.next() orelse return error.UnsafePath;
+    while (components.next()) |next| {
+        const child = try current.openDir(io, component, .{
+            .follow_symlinks = false,
+        });
+        if (owns_current) current.close(io);
+        current = child;
+        owns_current = true;
+        component = next;
+    }
+
+    const file = try current.openFile(io, component, .{
+        .allow_directory = false,
+        .follow_symlinks = false,
+        .resolve_beneath = true,
+    });
+    errdefer file.close(io);
+    const stat = try file.stat(io);
+    if (stat.kind != .file) return error.UnsupportedFileType;
+    return file;
+}
+
+test "opens a regular file below the supplied root" {
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "show/season");
+    try tmp.dir.writeFile(io, .{ .sub_path = "show/season/episode.mkv", .data = "media" });
+
+    var file = try openRegularAt(io, tmp.dir, "show/season/episode.mkv");
+    defer file.close(io);
+    var bytes: [5]u8 = undefined;
+    try std.testing.expectEqual(@as(usize, 5), try file.readPositionalAll(io, &bytes, 0));
+    try std.testing.expectEqualStrings("media", &bytes);
+}
+
+test "rejects traversal and platform-specific path syntax" {
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const attacks = [_][]const u8{
+        "../outside",
+        "nested/../../outside",
+        "/absolute",
+        "C:/Windows/win.ini",
+        "C:\\Windows\\win.ini",
+        "\\\\server\\share\\file",
+        "nested\\..\\outside",
+        "nested//file",
+        "nested/./file",
+    };
+    for (attacks) |attack|
+        try std.testing.expectError(error.UnsafePath, openRegularAt(io, tmp.dir, attack));
+}
+
+test "rejects a symlinked intermediate directory and final file" {
+    if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
+    const io = std.testing.io;
+    var root = std.testing.tmpDir(.{});
+    defer root.cleanup();
+    var outside = std.testing.tmpDir(.{});
+    defer outside.cleanup();
+
+    try outside.dir.writeFile(io, .{ .sub_path = "secret", .data = "outside" });
+    var file_target_buf: [64]u8 = undefined;
+    const file_target = try std.fmt.bufPrint(&file_target_buf, "../{s}/secret", .{outside.sub_path});
+    try root.dir.symLink(io, file_target, "final-link", .{});
+    if (openRegularAt(io, root.dir, "final-link")) |file| {
+        file.close(io);
+        return error.TestUnexpectedResult;
+    } else |_| {}
+
+    // The target only needs to be a directory: no bytes outside the root may
+    // be reachable, regardless of whether the symlink is relative or absolute.
+    var dir_target_buf: [64]u8 = undefined;
+    const dir_target = try std.fmt.bufPrint(&dir_target_buf, "../{s}", .{outside.sub_path});
+    try root.dir.symLink(io, dir_target, "dir-link", .{ .is_directory = true });
+    if (openRegularAt(io, root.dir, "dir-link/secret")) |file| {
+        file.close(io);
+        return error.TestUnexpectedResult;
+    } else |_| {}
+}
+
+test "rejects non-regular final objects" {
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(io, "directory", .default_dir);
+    try std.testing.expectError(error.IsDir, openRegularAt(io, tmp.dir, "directory"));
+}

--- a/src/services/remote_stream_pure.zig
+++ b/src/services/remote_stream_pure.zig
@@ -67,8 +67,17 @@ pub fn contentType(name: []const u8) []const u8 {
 pub fn safeRelPath(rel: []const u8) bool {
     if (rel.len == 0 or rel.len > 1024) return false;
     if (rel[0] == '/' or rel[0] == '\\') return false;
-    if (std.mem.indexOf(u8, rel, "..") != null) return false;
     if (std.mem.indexOfScalar(u8, rel, 0) != null) return false;
+    // Only '/' is accepted as a separator on every platform. Rejecting '\\'
+    // and ':' also closes Windows drive, UNC, device, and alternate-stream
+    // spellings when a request was produced on a different host OS.
+    if (std.mem.indexOfScalar(u8, rel, '\\') != null) return false;
+    if (std.mem.indexOfScalar(u8, rel, ':') != null) return false;
+    var parts = std.mem.splitScalar(u8, rel, '/');
+    while (parts.next()) |part| {
+        if (part.len == 0) return false;
+        if (std.mem.eql(u8, part, ".") or std.mem.eql(u8, part, "..")) return false;
+    }
     return true;
 }
 
@@ -141,6 +150,10 @@ test "safeRelPath blocks traversal and absolutes" {
     try std.testing.expect(!safeRelPath("/etc/passwd"));
     try std.testing.expect(!safeRelPath(""));
     try std.testing.expect(!safeRelPath("a/../b"));
+    try std.testing.expect(!safeRelPath("a\\..\\b"));
+    try std.testing.expect(!safeRelPath("C:/Windows/win.ini"));
+    try std.testing.expect(!safeRelPath("a//b"));
+    try std.testing.expect(safeRelPath("Show..Name/Episode.mkv"));
 }
 
 test "srtToVtt: header, comma→dot, index lines dropped, text preserved" {

--- a/src/services/resolver.zig
+++ b/src/services/resolver.zig
@@ -1499,7 +1499,7 @@ fn resolveYts(query_buf: [256]u8, qlen: usize) void {
     @import("../core/rate_limit.zig").acquire("yts", 1.0);
     const body = @import("../core/http.zig").fetch(url, &buf, .{
         .timeout_secs = 6,
-        .user_agent = "Opal/1.0",
+        .user_agent = @import("../core/app_meta.zig").user_agent,
     }) orelse {
         noteWorkerOutcome(.transport_failed);
         return;
@@ -1694,7 +1694,7 @@ fn resolveEztv(query_buf: [256]u8, qlen: usize) void {
 
     const body = @import("../core/mirrors.zig").fetch("eztv", page, .{
         .timeout_secs = 12,
-        .user_agent = "Opal/1.0",
+        .user_agent = @import("../core/app_meta.zig").user_agent,
     }, ctx, build) orelse {
         noteWorkerOutcome(.transport_failed);
         return;
@@ -1826,7 +1826,7 @@ fn resolveTorznabId(src_id: []const u8, query_buf: [256]u8, qlen: usize) void {
 
     const body = @import("../core/mirrors.zig").fetch(src_id, page_buf, .{
         .timeout_secs = 12,
-        .user_agent = "Opal/1.0",
+        .user_agent = @import("../core/app_meta.zig").user_agent,
     }, ctx, build) orelse {
         noteWorkerOutcome(.transport_failed);
         return;
@@ -1950,7 +1950,7 @@ fn resolveArchive(query_buf: [256]u8, qlen: usize) void {
     @import("../core/rate_limit.zig").acquire("archive", 1.0);
     const body = http.fetch(url, page, .{
         .timeout_secs = 8,
-        .user_agent = "Opal/1.0",
+        .user_agent = @import("../core/app_meta.zig").user_agent,
     }) orelse {
         noteWorkerOutcome(.transport_failed);
         return;
@@ -1984,7 +1984,7 @@ fn resolveArchive(query_buf: [256]u8, qlen: usize) void {
         @import("../core/rate_limit.zig").acquire("archive", 1.0);
         const meta = http.fetch(murl, meta_buf, .{
             .timeout_secs = 8,
-            .user_agent = "Opal/1.0",
+            .user_agent = @import("../core/app_meta.zig").user_agent,
         }) orelse {
             noteWorkerOutcome(.transport_failed);
             continue;
@@ -2148,7 +2148,7 @@ fn resolveNasa(query_buf: [256]u8, qlen: usize) void {
     @import("../core/rate_limit.zig").acquire("nasa", 1.0);
     const body = http.fetch(url, page, .{
         .timeout_secs = 8,
-        .user_agent = "Opal/1.0 (https://github.com/debpalash/Opal)",
+        .user_agent = @import("../core/app_meta.zig").user_agent_with_url,
     }) orelse {
         noteWorkerOutcome(.transport_failed);
         return;
@@ -2177,7 +2177,7 @@ fn resolveNasa(query_buf: [256]u8, qlen: usize) void {
         @import("../core/rate_limit.zig").acquire("nasa", 1.0);
         const coll = http.fetch(hit.href, coll_buf, .{
             .timeout_secs = 8,
-            .user_agent = "Opal/1.0 (https://github.com/debpalash/Opal)",
+            .user_agent = @import("../core/app_meta.zig").user_agent_with_url,
         }) orelse {
             noteWorkerOutcome(.transport_failed);
             continue;
@@ -2269,7 +2269,7 @@ fn resolveCommons(query_buf: [256]u8, qlen: usize) void {
     const body = http.fetch(url, page, .{
         .timeout_secs = 8,
         // Wikimedia UA policy requires a descriptive, contactable agent.
-        .user_agent = "Opal/1.0 (https://github.com/debpalash/Opal)",
+        .user_agent = @import("../core/app_meta.zig").user_agent_with_url,
     }) orelse {
         noteWorkerOutcome(.transport_failed);
         return;

--- a/src/services/search.zig
+++ b/src/services/search.zig
@@ -483,7 +483,7 @@ fn queryEztvApi(query: []const u8, allocator: std.mem.Allocator, my_gen: u64) vo
     const uri = std.Uri.parse(api_url) catch return;
     var req = client.request(.GET, uri, .{ .extra_headers = &.{
         .{ .name = "Accept", .value = "application/json" },
-        .{ .name = "User-Agent", .value = "Opal/1.0" },
+        .{ .name = "User-Agent", .value = @import("../core/app_meta.zig").user_agent },
     } }) catch return;
     defer req.deinit();
     req.sendBodiless() catch return;

--- a/src/services/tv_library.zig
+++ b/src/services/tv_library.zig
@@ -38,6 +38,8 @@ const icons = @import("icons");
 const tp = @import("tv_pure.zig");
 const cal_pure = @import("tv_calendar_pure.zig");
 const tmdb_api = @import("tmdb_api.zig");
+const components = @import("../ui/components.zig");
+const display_name = @import("../core/display_name_pure.zig");
 
 pub const MAX_SHOWS = tp.MAX_SHOWS;
 
@@ -618,7 +620,8 @@ fn addMovieRows() void {
 
         const r = nextRow() orelse return;
         r.kind = .movie;
-        r.setName(name);
+        var display_buf: [256]u8 = undefined;
+        r.setName(display_name.clean(&display_buf, name));
         r.setId(name);
         r.hist_idx = @intCast(i);
         r.pct = @floatCast(e.percent);
@@ -661,118 +664,260 @@ pub fn renderContent() void {
     var scroll = dvui.scrollArea(@src(), .{}, .{
         .expand = .both,
         .background = true,
-        .color_fill = theme.colors.bg_surface,
+        .color_fill = theme.colors.bg_app,
+        .gravity_y = 0,
     });
     defer scroll.deinit();
 
-    // Renders nothing when the plugin is absent or the feed is empty.
-    eztv.renderSection();
-
     if (row_count == 0) {
         renderEmpty();
-        return;
+    } else {
+        renderLibrary();
     }
-    renderGrid();
+
+    // Discovery is useful, but it is not the user's library. Keep the optional
+    // release feed below personal progress so opening Watching always answers
+    // "what should I continue?" first.
+    eztv.renderSection();
 }
 
 fn renderControlBar() void {
     var bar = dvui.box(@src(), .{ .dir = .vertical }, .{
         .expand = .horizontal,
         .background = true,
-        .color_fill = theme.colors.bg_surface,
-        .padding = .{ .x = theme.spacing.md, .y = theme.spacing.sm, .w = theme.spacing.md, .h = theme.spacing.sm },
+        .color_fill = theme.colors.bg_app,
+        .padding = .{ .x = theme.spacing.lg, .y = theme.spacing.md, .w = theme.spacing.lg, .h = theme.spacing.sm },
     });
     defer bar.deinit();
 
-    // Counts are cross-scoped: the status counts are computed WITHIN the active
-    // kind and vice-versa, so both rows always add up to what's actually on
-    // screen. A count that disagrees with the list is worse than no count.
     var counts: [6]usize = .{ 0, 0, 0, 0, 0, 0 };
     tp.countsFor(rows[0..row_count], kind_filter, &counts);
-    var kcounts: [4]usize = .{ 0, 0, 0, 0 };
-    tp.kindCountsFor(rows[0..row_count], filter, &kcounts);
 
-    // ── Kind row: All / TV / Anime / Movies ──
+    // Page identity + one useful summary. Counts no longer repeat inside every
+    // chip, which made the old toolbar read like a diagnostic panel.
     {
-        var krow = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal });
-        defer krow.deinit();
-
-        const kinds = [_]tp.KindFilter{ .all, .tv, .anime, .movie };
-        const knames = [_][]const u8{ "All", "TV", "Anime", "Movies" };
-        for (kinds, 0..) |k, i| {
-            var lbuf: [32]u8 = undefined;
-            const lbl = std.fmt.bufPrint(&lbuf, "{s} ({d})", .{ knames[i], kcounts[i] }) catch knames[i];
-            const sel = kind_filter == k;
-            if (dvui.button(@src(), lbl, .{}, .{
-                .id_extra = i + 60800,
-                .background = true,
-                .color_fill = if (sel) theme.colors.accent else theme.colors.bg_elevated,
-                .color_text = if (sel) theme.colors.text_on_accent else theme.colors.text_secondary,
-                .corner_radius = dvui.Rect.all(theme.radius.pill),
-                .margin = .{ .x = 0, .y = 0, .w = theme.spacing.sm, .h = 0 },
-                .padding = .{ .x = theme.spacing.md, .y = theme.spacing.xs, .w = theme.spacing.md, .h = theme.spacing.xs },
-            })) kind_filter = k;
+        var mast = dvui.box(@src(), .{ .dir = .horizontal }, .{ .expand = .horizontal });
+        defer mast.deinit();
+        {
+            var copy = dvui.box(@src(), .{ .dir = .vertical }, .{});
+            defer copy.deinit();
+            _ = dvui.label(@src(), "Watching", .{}, .{
+                .color_text = theme.colors.text_primary,
+                .font = dvui.themeGet().font_heading,
+            });
+            var summary_buf: [96]u8 = undefined;
+            const summary = std.fmt.bufPrint(&summary_buf, "{d} titles · {d} ready to continue", .{
+                counts[@intFromEnum(tp.Filter.all)],
+                counts[@intFromEnum(tp.Filter.watching)],
+            }) catch "Your saved progress";
+            _ = dvui.label(@src(), "{s}", .{summary}, .{
+                .color_text = theme.colors.text_tertiary,
+                .font = dvui.themeGet().font_body.withSize(theme.font_size.small),
+            });
         }
-
+        {
+            var spacer = dvui.box(@src(), .{}, .{ .expand = .horizontal });
+            spacer.deinit();
+        }
         if (isSyncing()) {
-            _ = dvui.label(@src(), "Syncing...", .{}, .{
-                .id_extra = 61500,
+            _ = dvui.label(@src(), "Refreshing metadata…", .{}, .{
                 .color_text = theme.colors.text_tertiary,
                 .gravity_y = 0.5,
-                .margin = .{ .x = theme.spacing.sm, .y = 0, .w = 0, .h = 0 },
             });
+        } else if (dvui.button(@src(), "Refresh", .{}, .{
+            .background = true,
+            .color_fill = theme.colors.bg_elevated,
+            .color_fill_hover = theme.colors.bg_hover,
+            .color_text = theme.colors.text_secondary,
+            .border = dvui.Rect.all(0),
+            .corner_radius = dvui.Rect.all(theme.radius.sm),
+            .padding = .{ .x = theme.spacing.md, .y = theme.spacing.xs, .w = theme.spacing.md, .h = theme.spacing.xs },
+            .gravity_y = 0.5,
+        })) {
+            resync();
         }
     }
 
-    // ── Status row: All / Watching / Caught up / Not started / Completed / Dropped ──
+    // One calm toolbar. Each control is a segmented group rather than ten
+    // unrelated pills, and the pair wraps as units on narrow windows.
+    var filters = dvui.flexbox(@src(), .{ .justify_content = .start }, .{
+        .expand = .horizontal,
+        .padding = .{ .x = 0, .y = theme.spacing.sm, .w = 0, .h = 0 },
+    });
+    defer filters.deinit();
     {
-        var srow = dvui.box(@src(), .{ .dir = .horizontal }, .{
-            .expand = .horizontal,
-            .padding = .{ .x = 0, .y = theme.spacing.xs, .w = 0, .h = 0 },
+        var group = dvui.box(@src(), .{ .dir = .vertical }, .{
+            .max_size_content = .{ .w = 340, .h = std.math.floatMax(f32) },
+            .margin = .{ .x = 0, .y = 0, .w = theme.spacing.md, .h = theme.spacing.xs },
         });
-        defer srow.deinit();
-
-        const chips = [_]tp.Filter{ .all, .watching, .caught_up, .unstarted, .completed, .dropped };
-        const names = [_][]const u8{ "All", "Watching", "Caught up", "Not started", "Completed", "Dropped" };
-        for (chips, 0..) |f, k| {
-            var lbuf: [40]u8 = undefined;
-            const lbl = std.fmt.bufPrint(&lbuf, "{s} ({d})", .{ names[k], counts[k] }) catch names[k];
-            const sel = filter == f;
-            if (dvui.button(@src(), lbl, .{}, .{
-                .id_extra = k + 61000,
-                .background = true,
-                .color_fill = if (sel) theme.colors.bg_hover else theme.colors.bg_surface,
-                .color_text = if (sel) theme.colors.text_primary else theme.colors.text_tertiary,
-                .corner_radius = dvui.Rect.all(theme.radius.pill),
-                .margin = .{ .x = 0, .y = 0, .w = theme.spacing.sm, .h = 0 },
-                .padding = .{ .x = theme.spacing.sm, .y = 2, .w = theme.spacing.sm, .h = 2 },
-            })) filter = f;
-        }
+        defer group.deinit();
+        _ = dvui.label(@src(), "TYPE", .{}, .{ .color_text = theme.colors.text_tertiary });
+        const labels = [_][]const u8{ "All", "TV", "Anime", "Movies" };
+        if (components.segment(@src(), &labels, @intFromEnum(kind_filter))) |picked|
+            kind_filter = @enumFromInt(picked);
+    }
+    {
+        var group = dvui.box(@src(), .{ .dir = .vertical }, .{
+            .max_size_content = .{ .w = 620, .h = std.math.floatMax(f32) },
+            .margin = .{ .x = 0, .y = 0, .w = 0, .h = theme.spacing.xs },
+        });
+        defer group.deinit();
+        _ = dvui.label(@src(), "PROGRESS", .{}, .{ .color_text = theme.colors.text_tertiary });
+        const labels = [_][]const u8{ "All", "In progress", "Caught up", "Planned", "Done", "Dropped" };
+        if (components.segment(@src(), &labels, @intFromEnum(filter))) |picked|
+            filter = @enumFromInt(picked);
     }
 }
 
 fn renderEmpty() void {
     var box = dvui.box(@src(), .{ .dir = .vertical }, .{
-        .expand = .both,
-        .gravity_x = 0.5,
-        .gravity_y = 0.5,
+        .expand = .horizontal,
+        .background = true,
+        .color_fill = theme.colors.bg_surface,
+        .corner_radius = dvui.Rect.all(theme.radius.md),
+        .padding = dvui.Rect.all(theme.spacing.lg),
+        .margin = .{ .x = theme.spacing.lg, .y = theme.spacing.md, .w = theme.spacing.lg, .h = theme.spacing.lg },
     });
     defer box.deinit();
 
-    _ = dvui.label(@src(), "Nothing tracked yet", .{}, .{
+    _ = dvui.label(@src(), "Nothing here yet", .{}, .{
         .id_extra = 62000,
         .color_text = theme.colors.text_primary,
         .font = dvui.themeGet().font_heading,
-        .gravity_x = 0.5,
     });
-    _ = dvui.label(@src(), "Play an episode, or set a status on any show or movie — it lands here with your progress.", .{}, .{
+    _ = dvui.label(@src(), "Save a show or movie and your next episode and progress will appear here.", .{}, .{
         .id_extra = 62001,
         .color_text = theme.colors.text_tertiary,
-        .gravity_x = 0.5,
+        .padding = .{ .x = 0, .y = theme.spacing.xs, .w = 0, .h = theme.spacing.md },
+    });
+
+    if (dvui.button(@src(), "Browse movies & TV", .{}, .{
+        .id_extra = 62002,
+        .background = true,
+        .color_fill = theme.colors.accent,
+        .color_text = theme.colors.text_on_accent,
+        .corner_radius = dvui.Rect.all(theme.radius.sm),
+        .padding = .{ .x = theme.spacing.md, .y = theme.spacing.sm, .w = theme.spacing.md, .h = theme.spacing.sm },
+    })) {
+        state.app.browse_source = .TMDB;
+        state.app.router.navigate(.browse);
+    }
+}
+
+const LibraryBucket = enum { all, up_next, saved };
+
+fn inBucket(r: *const tp.Row, bucket: LibraryBucket) bool {
+    return switch (bucket) {
+        .all => true,
+        .up_next => tp.isUpNext(r),
+        .saved => !tp.isUpNext(r),
+    };
+}
+
+fn visibleCount(bucket: LibraryBucket) usize {
+    var count: usize = 0;
+    for (order[0..row_count]) |idx| {
+        if (tp.visible(&rows[idx], filter, kind_filter) and inBucket(&rows[idx], bucket)) count += 1;
+    }
+    return count;
+}
+
+fn renderLibrary() void {
+    const is_default = filter == .all and kind_filter == .all;
+    if (!is_default) {
+        const count = visibleCount(.all);
+        if (count == 0) {
+            renderFilteredEmpty();
+            return;
+        }
+        renderSectionHeading("Filtered library", count, "titles");
+        renderGrid(.all);
+        return;
+    }
+
+    const up_next = visibleCount(.up_next);
+    const saved = visibleCount(.saved);
+
+    if (up_next > 0) {
+        renderSectionHeading("Up next", up_next, "ready");
+        renderUpNextRail();
+    }
+    if (saved > 0) {
+        renderSectionHeading("Your library", saved, "saved");
+        renderGrid(.saved);
+    }
+}
+
+fn renderSectionHeading(title: []const u8, count: usize, suffix: []const u8) void {
+    var heading = dvui.box(@src(), .{ .dir = .horizontal }, .{
+        .expand = .horizontal,
+        .padding = .{ .x = theme.spacing.lg, .y = theme.spacing.md, .w = theme.spacing.lg, .h = theme.spacing.xs },
+    });
+    defer heading.deinit();
+
+    _ = dvui.label(@src(), "{s}", .{title}, .{
+        .color_text = theme.colors.text_primary,
+        .font = dvui.themeGet().font_body.withSize(theme.font_size.title),
+        .gravity_y = 0.5,
+    });
+    _ = dvui.label(@src(), "{d} {s}", .{ count, suffix }, .{
+        .color_text = theme.colors.text_tertiary,
+        .font = dvui.themeGet().font_body.withSize(theme.font_size.small),
+        .gravity_y = 0.5,
+        .margin = .{ .x = theme.spacing.sm, .y = 0, .w = 0, .h = 0 },
     });
 }
 
-fn renderGrid() void {
+fn renderUpNextRail() void {
+    const media_card = @import("../ui/media_card.zig");
+    var rail = dvui.scrollArea(@src(), .{ .horizontal = .auto, .vertical = .none, .horizontal_bar = .hide }, .{
+        .expand = .horizontal,
+        .background = false,
+        .min_size_content = .{ .w = 10, .h = media_card.cardHeight(true, true) + 12 },
+        .max_size_content = .{ .w = std.math.floatMax(f32), .h = std.math.floatMax(f32) },
+        .padding = .{ .x = theme.spacing.md, .y = 0, .w = theme.spacing.md, .h = 0 },
+        .gravity_y = 0,
+    });
+    defer rail.deinit();
+
+    var row = dvui.box(@src(), .{ .dir = .horizontal }, .{ .gravity_y = 0 });
+    defer row.deinit();
+    for (order[0..row_count]) |idx| {
+        if (!tp.visible(&rows[idx], filter, kind_filter) or !inBucket(&rows[idx], .up_next)) continue;
+        renderCard(idx, idx);
+    }
+}
+
+fn renderFilteredEmpty() void {
+    var box = dvui.box(@src(), .{ .dir = .vertical }, .{
+        .expand = .horizontal,
+        .background = true,
+        .color_fill = theme.colors.bg_surface,
+        .corner_radius = dvui.Rect.all(theme.radius.md),
+        .padding = dvui.Rect.all(theme.spacing.lg),
+        .margin = .{ .x = theme.spacing.lg, .y = theme.spacing.md, .w = theme.spacing.lg, .h = theme.spacing.lg },
+    });
+    defer box.deinit();
+
+    _ = dvui.label(@src(), "No titles match these filters", .{}, .{
+        .color_text = theme.colors.text_primary,
+        .font = dvui.themeGet().font_heading,
+    });
+    if (dvui.button(@src(), "Clear filters", .{}, .{
+        .color_fill = theme.colors.bg_elevated,
+        .color_fill_hover = theme.colors.bg_hover,
+        .color_text = theme.colors.text_primary,
+        .border = dvui.Rect.all(0),
+        .corner_radius = dvui.Rect.all(theme.radius.sm),
+        .padding = .{ .x = theme.spacing.md, .y = theme.spacing.xs, .w = theme.spacing.md, .h = theme.spacing.xs },
+        .margin = .{ .x = 0, .y = theme.spacing.sm, .w = 0, .h = 0 },
+    })) {
+        filter = .all;
+        kind_filter = .all;
+    }
+}
+
+fn renderGrid(bucket: LibraryBucket) void {
     const avail_w = dvui.parentGet().data().contentRect().w;
     const per_card = CARD_W + 12;
     const cols: usize = @max(1, @as(usize, @intFromFloat(@max(1, avail_w / per_card))));
@@ -780,6 +925,7 @@ fn renderGrid() void {
     var grid = dvui.box(@src(), .{ .dir = .vertical }, .{
         .expand = .horizontal,
         .padding = dvui.Rect.all(theme.spacing.sm),
+        .gravity_y = 0,
     });
     defer grid.deinit();
 
@@ -787,18 +933,9 @@ fn renderGrid() void {
     var visible: [MAX_SHOWS]u16 = undefined;
     var vn: usize = 0;
     for (order[0..row_count]) |idx| {
-        if (!tp.visible(&rows[idx], filter, kind_filter)) continue;
+        if (!tp.visible(&rows[idx], filter, kind_filter) or !inBucket(&rows[idx], bucket)) continue;
         visible[vn] = idx;
         vn += 1;
-    }
-
-    if (vn == 0) {
-        _ = dvui.label(@src(), "Nothing in this filter.", .{}, .{
-            .id_extra = 62100,
-            .color_text = theme.colors.text_tertiary,
-            .gravity_x = 0.5,
-        });
-        return;
     }
 
     var i: usize = 0;
@@ -807,12 +944,15 @@ fn renderGrid() void {
         var hrow = dvui.box(@src(), .{ .dir = .horizontal }, .{
             .id_extra = row_i + 63000,
             .expand = .horizontal,
+            .gravity_y = 0,
         });
         defer hrow.deinit();
 
         var col: usize = 0;
         while (col < cols and i < vn) : (col += 1) {
-            renderCard(visible[i], i);
+            // Row identity is unique across the Up-next rail and this grid;
+            // a per-section ordinal can collide with a card rendered above.
+            renderCard(visible[i], visible[i]);
             i += 1;
         }
     }

--- a/src/services/tv_pure.zig
+++ b/src/services/tv_pure.zig
@@ -529,6 +529,13 @@ pub fn visible(r: *const Row, f: Filter, k: KindFilter) bool {
     return matchesFilter(r, f) and matchesKind(r, k);
 }
 
+/// The default Watching view promotes only active work. Everything else stays
+/// available in the library below without competing with the next thing to
+/// play.
+pub fn isUpNext(r: *const Row) bool {
+    return r.status == .watching;
+}
+
 /// Counts per status chip, indexed by `@intFromEnum(Filter)`. Counted WITHIN the
 /// active kind filter, so the numbers always add up to what is on screen — a
 /// count that disagrees with the list is worse than no count.
@@ -935,6 +942,18 @@ test "counts are scoped to the OTHER chip row (they must add up to the list)" {
 
     try t.expect(visible(&rows[1], .watching, .anime));
     try t.expect(!visible(&rows[1], .watching, .tv));
+}
+
+test "up next contains active work only" {
+    var active: Row = .{};
+    active.status = .watching;
+    try t.expect(isUpNext(&active));
+
+    inline for (.{ Status.caught_up, Status.unstarted, Status.completed, Status.dropped }) |status| {
+        var row: Row = .{};
+        row.status = status;
+        try t.expect(!isUpNext(&row));
+    }
 }
 
 test "user status always beats the derived one" {

--- a/src/services/youtube.zig
+++ b/src/services/youtube.zig
@@ -861,7 +861,7 @@ fn fetchViaPiped(query: []const u8, gen: u32) bool {
         var req = client.request(.GET, uri, .{
             .extra_headers = &.{
                 .{ .name = "Accept", .value = "application/json" },
-                .{ .name = "User-Agent", .value = "Mozilla/5.0 (X11; Linux x86_64) Opal/1.0" },
+                .{ .name = "User-Agent", .value = @import("../core/app_meta.zig").browser_user_agent },
             },
         }) catch continue;
         defer req.deinit();
@@ -1681,7 +1681,7 @@ fn fireSuggest(query: []const u8) void {
             var req = client.request(.GET, uri, .{
                 .extra_headers = &.{
                     .{ .name = "Accept", .value = "application/json" },
-                    .{ .name = "User-Agent", .value = "Mozilla/5.0 (X11; Linux x86_64) Opal/1.0" },
+                    .{ .name = "User-Agent", .value = @import("../core/app_meta.zig").browser_user_agent },
                 },
             }) catch return;
             defer req.deinit();

--- a/src/ui/grid.zig
+++ b/src/ui/grid.zig
@@ -10,6 +10,7 @@ const transfers = @import("../services/transfers.zig");
 const theme = @import("theme.zig");
 const metadata_dialog = @import("metadata_dialog.zig");
 const components = @import("components.zig");
+const display_name_pure = @import("../core/display_name_pure.zig");
 
 /// Normalize a path / URL into a user-facing display name:
 ///   1. basename (after last `/` or `\\`)
@@ -19,50 +20,7 @@ const components = @import("components.zig");
 /// Writes into `out` (capacity = `out.len`) and returns the populated
 /// slice. Returns `raw` unchanged if cleanup would produce an empty
 /// string.
-pub fn cleanDisplayName(out: []u8, raw: []const u8) []const u8 {
-    if (out.len == 0) return raw;
-
-    // Step 1: basename
-    var basename_start: usize = 0;
-    for (raw, 0..) |ch, ci| {
-        if (ch == '/' or ch == '\\') basename_start = ci + 1;
-    }
-    const basename = raw[basename_start..];
-
-    // Step 2: strip short extension
-    var name_end: usize = basename.len;
-    {
-        var last_dot: ?usize = null;
-        for (basename, 0..) |ch, ci| {
-            if (ch == '.') last_dot = ci;
-        }
-        if (last_dot) |dot| {
-            if (basename.len - dot <= 6) name_end = dot;
-        }
-    }
-    const stripped = basename[0..name_end];
-
-    // Step 3: replace dots/underscores with spaces, collapse multiples
-    var written: usize = 0;
-    for (stripped) |ch| {
-        if (written >= out.len - 1) break;
-        const out_ch: u8 = if (ch == '.' or ch == '_') ' ' else ch;
-        if (out_ch == ' ' and written > 0 and out[written - 1] == ' ') continue;
-        out[written] = out_ch;
-        written += 1;
-    }
-
-    // Step 4: trim trailing then leading spaces
-    while (written > 0 and out[written - 1] == ' ') written -= 1;
-    var trim_start: usize = 0;
-    while (trim_start < written and out[trim_start] == ' ') trim_start += 1;
-    if (trim_start > 0 and trim_start < written) {
-        std.mem.copyForwards(u8, out[0 .. written - trim_start], out[trim_start..written]);
-        written -= trim_start;
-    }
-
-    return if (written > 0) out[0..written] else raw;
-}
+pub const cleanDisplayName = display_name_pure.clean;
 
 /// The chat transcript: inline result cards + message bubbles + phase label.
 /// NO scroll wrapper — the host (home.zig's chat mode) owns the page scroll,

--- a/tests/features/test_build.py
+++ b/tests/features/test_build.py
@@ -661,6 +661,35 @@ def test_version_single_source():
     return "pass", "APP_VERSION comes from build.zig.zon via build_options; no hand-maintained copy"
 
 
+@test("Host API and application user agents use the canonical version", "Build")
+def test_version_reaches_host_api_and_user_agents():
+    meta = _src("src/core/app_meta.zig")
+    remote = _src("src/services/remote.zig")
+    host = _src("src/services/remote_host_pure.zig")
+    all_zig = "\n".join(
+        _src(os.path.relpath(os.path.join(root, name), PROJECT_DIR))
+        for root, _, names in os.walk(os.path.join(PROJECT_DIR, "src"))
+        for name in names
+        if name.endswith(".zig")
+    )
+    contributing = _src(".github/CONTRIBUTING.md")
+    checks = {
+        "metadata reads build option": '@import("build_options").app_version' in meta,
+        "host reports metadata version": 'remote_host_pure.zig' in remote
+            and '@import("../core/app_meta.zig").version' in remote
+            and '@import("build_options").app_version' in host
+            and r'\"version\":\"{s}\"' in host,
+        "release user agent is derived": '"Opal/" ++ version' in meta,
+        "legacy host literal removed": '"0.1.2"' not in remote,
+        "legacy user agents removed": "Opal/1.0" not in all_zig,
+        "development representation documented": "do not add an implicit `-dev` suffix" in contributing,
+    }
+    missing = [k for k, v in checks.items() if not v]
+    if missing:
+        return "fail", "canonical version does not reach every release identity: " + ", ".join(missing)
+    return "pass", "/api/host and Opal user agents derive from build.zig.zon"
+
+
 @test("Every release ships highlights and a commit list", "Packaging")
 def test_release_notes():
     """Every release through v0.6.4 published a body of exactly one line:

--- a/tests/features/test_page_shell3.py
+++ b/tests/features/test_page_shell3.py
@@ -64,7 +64,7 @@ def test_tv_tracking():
         # The Watching library is not TV-only.
         "all kinds aggregated": ("fn addTvRows(" in lib and "fn addAnimeRows(" in lib
                                  and "fn addMovieRows(" in lib),
-        "kind chips": "tp.kindCountsFor(" in lib and "kind_filter" in lib,
+        "kind filters": "components.segment(" in lib and "kind_filter" in lib,
         # A TV episode also lands in watch_history under its release name; listing
         # it as a "movie" would duplicate the show under a worse identity.
         "episodes excluded from movies": "subs.parse(name, &qbuf, &showbuf).is_tv" in lib,
@@ -92,6 +92,33 @@ def test_tv_tracking():
     if missing:
         return "fail", "missing: " + ", ".join(missing)
     return "pass", "TV+anime+movies in one library; aired-clamped next-up; user-set status"
+
+
+@test("Watching page: progress-first layout", "Page Shell")
+def test_watching_progress_first_layout():
+    lib = _src("src/services/tv_library.zig")
+    pure = _src("src/services/tv_pure.zig")
+    names = _src("src/core/display_name_pure.zig")
+    build = _src("build.zig")
+    checks = {
+        "personal library before releases": lib.index("renderLibrary();") < lib.index("eztv.renderSection();"),
+        "up-next rail": ("fn renderUpNextRail()" in lib
+                         and "tp.isUpNext(" in lib
+                         and "pub fn isUpNext(" in pure),
+        "saved library section": ('renderSectionHeading("Your library"' in lib
+                                  and "renderGrid(.saved)" in lib),
+        "top-aligned content": ".gravity_y = 0" in _between(lib, "pub fn renderContent", "fn renderControlBar"),
+        "quiet segmented filters": "components.segment(" in lib,
+        "useful empty states": ('"Browse movies & TV"' in lib
+                                and '"Clear filters"' in lib),
+        "local filenames cleaned": ("display_name.clean(" in lib
+                                    and "pub fn clean(" in names
+                                    and "display_name_pure.zig" in build),
+    }
+    missing = [k for k, v in checks.items() if not v]
+    if missing:
+        return "fail", "watching layout incomplete: " + ", ".join(missing)
+    return "pass", "up next first; saved library and releases follow; no centered dead space"
 
 
 @test("Player control bar: drop-ups + FF fullscreen", "Page Shell")

--- a/tests/features/test_player.py
+++ b/tests/features/test_player.py
@@ -323,7 +323,7 @@ def test_hosted_mode_and_perf():
     checks = {
         "range streaming": "parseRange" in rp and "206 Partial Content" in rs,
         "srt→vtt": "srtToVtt" in rp and "handleVtt" in rs,
-        "traversal guard": "safeRelPath" in rp and "safeRelPath" in rs,
+        "traversal guard": "safeRelPath" in rp and "secure_path.openRegularAt" in rs,
         "query-token media auth": '"/stream"' in rm and 'getQueryParam(query, "t")' in rm,
         "parity routes": '"/calendar"' in rm and '"/tv"' in rm and '"/host"' in rm and '"/torrents"' in rm,
         "thread-per-conn + api mutex": "api_mutex" in rm and "Thread.spawn(.{}, Handler.run" in rm,

--- a/tests/features/test_scrape_fetch.py
+++ b/tests/features/test_scrape_fetch.py
@@ -140,7 +140,8 @@ def test_scrapers_routed_through_scrapefetch():
         "mangadex at-home on fetchUrl": "fetchUrl(ah_url, ah_buf)" in comics,
         "mangadex not browser-routed": "fetchMaybeUnblocked(feed_url" not in comics
             and "fetchMaybeUnblocked(ah_url" not in comics,
-        "per-host UA preserved": "pure.userAgentFor(url)" in comics,
+        "per-host UA preserved": "pure.userAgentFor(url, " in comics
+            and "app_meta.zig" in comics,
         # HeanCms JSON API likewise stays on fetchUrl.
         "heancms detail on fetchUrl": "fetchUrl(detail_url, detail_buf)" in comics,
 

--- a/tests/features/test_stability.py
+++ b/tests/features/test_stability.py
@@ -180,7 +180,7 @@ def test_legal_directplay_sources():
         "commons spawned under stremio": "Spawn.go(resolveCommons, &status_commons)" in rv,
         "commons in checkAllDone": "status_commons.load(.acquire) != .searching" in rv,
         "commons endpoint": "commons.wikimedia.org/w/api.php" in rv,
-        "commons UA policy": "https://github.com/debpalash/Opal" in rv,
+        "commons UA policy": "user_agent_with_url" in rv,
         "commons_pure iteratePages": "pub fn iteratePages(" in cpu and "stripFilePrefix" in cpu,
         "commons_pure registered": "commons_pure.zig" in bz,
         # IA audio: intent-aware, no new worker, librivox/etree, VBR>ogg>flac

--- a/tests/results.json
+++ b/tests/results.json
@@ -1,10 +1,10 @@
 {
-  "timestamp": "2026-08-13T12:54:36",
-  "total": 421,
-  "passed": 408,
-  "failed": 0,
-  "warnings": 4,
-  "skipped": 9,
+  "timestamp": "2026-08-23T11:14:48",
+  "total": 423,
+  "passed": 411,
+  "failed": 1,
+  "warnings": 3,
+  "skipped": 8,
   "categories": {
     "Database": {
       "pass": 10,
@@ -19,10 +19,10 @@
       "skip": 0
     },
     "Config": {
-      "pass": 5,
+      "pass": 6,
       "fail": 0,
       "warn": 0,
-      "skip": 1
+      "skip": 0
     },
     "Recall": {
       "pass": 3,
@@ -32,7 +32,7 @@
     },
     "Build": {
       "pass": 10,
-      "fail": 0,
+      "fail": 1,
       "warn": 1,
       "skip": 0
     },
@@ -73,9 +73,9 @@
       "skip": 0
     },
     "Voice": {
-      "pass": 7,
+      "pass": 8,
       "fail": 0,
-      "warn": 1,
+      "warn": 0,
       "skip": 4
     },
     "Voice Scripts": {
@@ -223,7 +223,7 @@
       "skip": 0
     },
     "Page Shell": {
-      "pass": 48,
+      "pass": 49,
       "fail": 0,
       "warn": 0,
       "skip": 0
@@ -318,7 +318,7 @@
       "name": "Database Exists",
       "category": "Database",
       "status": "pass",
-      "detail": "Size: 19572.0 KB",
+      "detail": "Size: 30320.0 KB",
       "duration_ms": 0
     },
     {
@@ -326,27 +326,27 @@
       "category": "Database",
       "status": "pass",
       "detail": "85 config entries",
-      "duration_ms": 0
+      "duration_ms": 2
     },
     {
       "name": "Watch History Table",
       "category": "Database",
       "status": "pass",
-      "detail": "0 watch entries",
+      "detail": "4 watch entries",
       "duration_ms": 0
     },
     {
       "name": "Search History Table",
       "category": "Database",
       "status": "pass",
-      "detail": "5 searches",
+      "detail": "11 searches",
       "duration_ms": 0
     },
     {
       "name": "Download History Table",
       "category": "Database",
       "status": "pass",
-      "detail": "2 downloads",
+      "detail": "3 downloads",
       "duration_ms": 0
     },
     {
@@ -374,21 +374,21 @@
       "name": "Poster Cache Table",
       "category": "Database",
       "status": "pass",
-      "detail": "641 cached posters",
-      "duration_ms": 0
+      "detail": "793 cached posters",
+      "duration_ms": 1
     },
     {
       "name": "Conversation Log Table",
       "category": "Memory",
       "status": "pass",
-      "detail": "0 logged conversations",
+      "detail": "15 logged conversations",
       "duration_ms": 0
     },
     {
       "name": "User Preferences Table",
       "category": "Memory",
       "status": "pass",
-      "detail": "active_hour=16:00 (w:11)",
+      "detail": "active_hour=0:00 (w:381)",
       "duration_ms": 0
     },
     {
@@ -409,14 +409,14 @@
       "name": "Theme Persistence",
       "category": "Config",
       "status": "pass",
-      "detail": "Theme: Midnight",
+      "detail": "Theme: Solarized",
       "duration_ms": 0
     },
     {
       "name": "UI Scale Config",
       "category": "Config",
       "status": "pass",
-      "detail": "Scale: 2.00x",
+      "detail": "Scale: 0.80x",
       "duration_ms": 0
     },
     {
@@ -437,14 +437,14 @@
       "name": "Window State Persistence",
       "category": "Config",
       "status": "pass",
-      "detail": "3686x2314 at (52,308)",
+      "detail": "1280x803 at (0,29)",
       "duration_ms": 0
     },
     {
       "name": "Jellyfin Integration Config",
       "category": "Config",
-      "status": "skip",
-      "detail": "Not configured",
+      "status": "pass",
+      "detail": "Server: http://localhost:8096",
       "duration_ms": 0
     },
     {
@@ -493,14 +493,14 @@
       "name": "Zig Build",
       "category": "Build",
       "status": "pass",
-      "detail": "Binary: 52.9 MB",
-      "duration_ms": 79
+      "detail": "Binary: 50.7 MB",
+      "duration_ms": 521
     },
     {
       "name": "Binary Exists",
       "category": "Build",
       "status": "pass",
-      "detail": "52.9 MB, built at 12:53:59",
+      "detail": "50.7 MB, built at 11:13:05",
       "duration_ms": 0
     },
     {
@@ -521,7 +521,7 @@
       "name": "Libtorrent Wrapper",
       "category": "Build",
       "status": "pass",
-      "detail": "129 KB",
+      "detail": "108 KB",
       "duration_ms": 0
     },
     {
@@ -536,7 +536,7 @@
       "category": "LLM",
       "status": "skip",
       "detail": "LLM server not running",
-      "duration_ms": 13
+      "duration_ms": 22
     },
     {
       "name": "Embedding Server Health",
@@ -550,7 +550,7 @@
       "category": "Server",
       "status": "pass",
       "detail": "compile-time headless entry + coreInit/headlessMain + 0.0.0.0 bind + -Dheadless",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "name": "Headless Render Guards",
@@ -564,7 +564,7 @@
       "category": "Unit Tests",
       "status": "pass",
       "detail": "all pure-Zig unit tests pass",
-      "duration_ms": 1314
+      "duration_ms": 6157
     },
     {
       "name": "Poster/image fetch uses curl not std.http",
@@ -634,7 +634,7 @@
       "category": "Packaging",
       "status": "pass",
       "detail": "default path calls no sudo and installs executable + nova2 under ~/.local",
-      "duration_ms": 36
+      "duration_ms": 1910
     },
     {
       "name": "File associations + single instance",
@@ -658,11 +658,18 @@
       "duration_ms": 0
     },
     {
+      "name": "Host API and application user agents use the canonical version",
+      "category": "Build",
+      "status": "pass",
+      "detail": "/api/host and Opal user agents derive from build.zig.zon",
+      "duration_ms": 22
+    },
+    {
       "name": "Every release ships highlights and a commit list",
       "category": "Packaging",
       "status": "pass",
       "detail": "notes = CHANGELOG highlights + generated commits; 14 versions documented",
-      "duration_ms": 36
+      "duration_ms": 124
     },
     {
       "name": "First-run onboarding actually runs on first run",
@@ -676,14 +683,14 @@
       "category": "Build",
       "status": "pass",
       "detail": "39 workflow shell step(s) parse under bash -n",
-      "duration_ms": 62
+      "duration_ms": 193
     },
     {
       "name": "No AI attribution in commit trailers",
       "category": "Build",
-      "status": "pass",
-      "detail": "52 commit(s) since the rule, none with AI attribution",
-      "duration_ms": 70
+      "status": "fail",
+      "detail": "AI attribution in commit(s): 3a06783",
+      "duration_ms": 681
     },
     {
       "name": "The landing page's photographic bands are static and present",
@@ -710,7 +717,7 @@
       "name": "The landing page's comparison and SEO metadata hold up",
       "category": "Packaging",
       "status": "pass",
-      "detail": "matrix vs 5 products, sourced; JSON-LD parses (WebSite, WebPage, SoftwareApplication)",
+      "detail": "matrix vs 5 products, sourced; JSON-LD parses (SoftwareApplication, WebSite)",
       "duration_ms": 0
     },
     {
@@ -732,35 +739,35 @@
       "category": "Voice",
       "status": "skip",
       "detail": "silero-vad not installed (optional)",
-      "duration_ms": 55
+      "duration_ms": 779
     },
     {
       "name": "Faster-Whisper Available",
       "category": "Voice",
-      "status": "skip",
-      "detail": "faster-whisper not installed (optional)",
-      "duration_ms": 55
+      "status": "pass",
+      "detail": "faster-whisper importable",
+      "duration_ms": 1030
     },
     {
       "name": "KittenTTS Available",
       "category": "Voice",
       "status": "skip",
       "detail": "kittentts not installed (optional)",
-      "duration_ms": 58
+      "duration_ms": 22
     },
     {
       "name": "PulseAudio Echo Cancel",
       "category": "Voice",
-      "status": "warn",
-      "detail": "Not loaded (loads on voice server start)",
-      "duration_ms": 5
+      "status": "skip",
+      "detail": "pactl not available",
+      "duration_ms": 2
     },
     {
       "name": "Conversational: voice-server echo guard + live partials",
       "category": "Voice",
       "status": "pass",
       "detail": "echo guard drops self-echo; real interruption passes; PARTIAL streamed",
-      "duration_ms": 19
+      "duration_ms": 33
     },
     {
       "name": "Conversational: prefer full-duplex event loop + wiring",
@@ -774,56 +781,56 @@
       "category": "Voice Scripts",
       "status": "pass",
       "detail": "py_compile OK",
-      "duration_ms": 24
+      "duration_ms": 25
     },
     {
       "name": "Compiles: opal-stt-server.py",
       "category": "Voice Scripts",
       "status": "pass",
       "detail": "py_compile OK",
-      "duration_ms": 25
+      "duration_ms": 26
     },
     {
       "name": "Compiles: opal-tts-server.py",
       "category": "Voice Scripts",
       "status": "pass",
       "detail": "py_compile OK",
-      "duration_ms": 26
+      "duration_ms": 25
     },
     {
       "name": "Compiles: opal-voice-server.py",
       "category": "Voice Scripts",
       "status": "pass",
       "detail": "py_compile OK",
-      "duration_ms": 27
+      "duration_ms": 26
     },
     {
       "name": "--check degrades: opal-stt-server.py",
       "category": "Voice Scripts",
       "status": "pass",
-      "detail": "clean exit 4 (deps absent (fallback))",
-      "duration_ms": 17
+      "detail": "clean exit 0 (deps present)",
+      "duration_ms": 1013
     },
     {
       "name": "--check degrades: opal-tts-server.py",
       "category": "Voice Scripts",
       "status": "pass",
       "detail": "clean exit 4 (deps absent (fallback))",
-      "duration_ms": 18
+      "duration_ms": 33
     },
     {
       "name": "--check degrades: opal-voice-server.py",
       "category": "Voice Scripts",
       "status": "pass",
-      "detail": "clean exit 4 (deps absent (fallback))",
-      "duration_ms": 18
+      "detail": "clean exit 0 (deps present)",
+      "duration_ms": 1055
     },
     {
       "name": "Tracked + compiles: tools/lang_server.py",
       "category": "Voice Scripts",
       "status": "pass",
       "detail": "tracked + py_compile OK",
-      "duration_ms": 27
+      "duration_ms": 41
     },
     {
       "name": "Parakeet conversational self-install wired",
@@ -850,7 +857,7 @@
       "name": "STT End-to-End (say\u2192whisper)",
       "category": "Voice Scripts",
       "status": "skip",
-      "detail": "macOS-only smoke test",
+      "detail": "no ggml model",
       "duration_ms": 0
     },
     {
@@ -1026,14 +1033,14 @@
       "category": "AI Models",
       "status": "pass",
       "detail": "all 5 URLs resolve (HTTP 200)",
-      "duration_ms": 5491
+      "duration_ms": 9616
     },
     {
       "name": "Cloud LLM Backend + No Silent Local Installs",
       "category": "AI Features",
       "status": "pass",
       "detail": "cloud providers + bearer auth + on-demand-only local models wired",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "Parakeet TDT Voice Backend Wired",
@@ -1061,14 +1068,14 @@
       "category": "Enrichment",
       "status": "pass",
       "detail": "OMDb enrichment wired (parser+worker+UI+persist); key set=False",
-      "duration_ms": 1
+      "duration_ms": 3
     },
     {
       "name": "Local taste engine: activity + vectors + For You",
       "category": "AI",
       "status": "pass",
       "detail": "activity log + vec_taste vectors + gated For You tier wired",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "Theme Presets Defined",
@@ -1110,21 +1117,21 @@
       "category": "Browser",
       "status": "pass",
       "detail": "py_compile OK",
-      "duration_ms": 31
+      "duration_ms": 40
     },
     {
       "name": "Bridge protocol selftest",
       "category": "Browser",
       "status": "pass",
       "detail": "framing + pump model OK",
-      "duration_ms": 21
+      "duration_ms": 32
     },
     {
       "name": "Browser bookmarks SQL matches schema",
       "category": "Browser",
       "status": "pass",
       "detail": "3 statements OK against schema",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "browser_pure registered in zig tests",
@@ -1138,35 +1145,35 @@
       "category": "UI Standards",
       "status": "pass",
       "detail": "no emoji in UI string literals",
-      "duration_ms": 52
+      "duration_ms": 86
     },
     {
       "name": "Browser: CloakBrowser engine + upgrades",
       "category": "Browser",
       "status": "pass",
       "detail": "engine picker + find/zoom/downloads/history/reader wired",
-      "duration_ms": 55
+      "duration_ms": 60
     },
     {
       "name": "Every widget follows the active theme (no bare-options dvui widgets)",
       "category": "Theming",
       "status": "pass",
       "detail": "no bare-options dvui widgets \u2014 all buttons route through themed helpers",
-      "duration_ms": 30
+      "duration_ms": 47
     },
     {
       "name": "Theme colors are read per-frame, not cached at module scope",
       "category": "Theming",
       "status": "pass",
       "detail": "no raw Color literals in ui/ \u2014 colors come from theme.colors.*",
-      "duration_ms": 5
+      "duration_ms": 9
     },
     {
       "name": "Typed Playback Load Seam",
       "category": "Player",
       "status": "pass",
       "detail": "replace clears legacy globals; per-entry options preserve append isolation; no raw bypass",
-      "duration_ms": 11
+      "duration_ms": 16
     },
     {
       "name": "Single-Media Mode",
@@ -1243,7 +1250,7 @@
       "category": "Remote",
       "status": "pass",
       "detail": "account auth (no pairing) + LAN bind + bundled page",
-      "duration_ms": 1
+      "duration_ms": 2
     },
     {
       "name": "Hosted Mode: Stream/VTT/Poster + Docker + Perf Fixes",
@@ -1376,7 +1383,7 @@
       "category": "Player",
       "status": "pass",
       "detail": "anime-skip: findEpisodeByName \u2192 point\u2192range \u2192 gated auto-seek",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "name": "Torrent file loading",
@@ -1432,7 +1439,7 @@
       "category": "Player",
       "status": "pass",
       "detail": "3 upstream options (spdif=ac3,dts,eac3), all default off, no fork-only flags that would break a system mpv",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "name": "Download limit: 0 means unlimited all the way to libtorrent",
@@ -1502,7 +1509,7 @@
       "category": "Stability",
       "status": "pass",
       "detail": "all 75 default-valued fields assigned in init",
-      "duration_ms": 1
+      "duration_ms": 2
     },
     {
       "name": "Stream Resources Resolvable When Bundled",
@@ -1551,7 +1558,7 @@
       "category": "Stability",
       "status": "pass",
       "detail": "no discarded std.Thread.spawn handles in src/",
-      "duration_ms": 19
+      "duration_ms": 25
     },
     {
       "name": "TMDB Fetch Stages Results Off-Thread",
@@ -1621,7 +1628,7 @@
       "category": "Page Shell",
       "status": "pass",
       "detail": "services navigate via navigateToTab",
-      "duration_ms": 13
+      "duration_ms": 16
     },
     {
       "name": "Omnibox \u2192 Unified Search",
@@ -1782,7 +1789,7 @@
       "category": "Page Shell",
       "status": "pass",
       "detail": "canonical tokens only; legacy aliases deleted",
-      "duration_ms": 7
+      "duration_ms": 186
     },
     {
       "name": "Compact Type Ramp Drives dvui Fonts",
@@ -1894,7 +1901,14 @@
       "category": "Page Shell",
       "status": "pass",
       "detail": "TV+anime+movies in one library; aired-clamped next-up; user-set status",
-      "duration_ms": 1
+      "duration_ms": 0
+    },
+    {
+      "name": "Watching page: progress-first layout",
+      "category": "Page Shell",
+      "status": "pass",
+      "detail": "up next first; saved library and releases follow; no centered dead space",
+      "duration_ms": 0
     },
     {
       "name": "Player control bar: drop-ups + FF fullscreen",
@@ -1957,7 +1971,7 @@
       "category": "Reading",
       "status": "pass",
       "detail": "OPDS client wired: pure parser routed, config keys, tab + dispatch, comics reuse, settings section, OPDS-PSE page streaming (parse + pageUrl + Basic-auth forwarded)",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "name": "Comic reading position persists",
@@ -1999,7 +2013,7 @@
       "category": "Transfers",
       "status": "pass",
       "detail": "gallery-dl backend wired: pure\u2192service\u2192dispatch\u2192history+config. gallery-dl not installed (backend inert \u2014 pure tests cover logic)",
-      "duration_ms": 1
+      "duration_ms": 6
     },
     {
       "name": "VNDB visual-novel catalog",
@@ -2013,7 +2027,7 @@
       "category": "Reading",
       "status": "pass",
       "detail": "drama wired: pure(parse/classify) \u2192 enum\u2192nav\u2192service (TMDB), play\u2192resolver\u2192load_file/gotoPlayer; tokusatsu lane removed",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "Anime airing schedule + ANN feed",
@@ -2055,14 +2069,14 @@
       "category": "Integration",
       "status": "pass",
       "detail": "306 SFW sources (heancms=13, madara=186, mangathemesia=107); opt-in via installMangaSource + /source/catalog, all route through source_config.install",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "Anti-block scrape fetch",
       "category": "Network",
       "status": "pass",
       "detail": "anti-block fetch wired: pure(isBlocked/needsBrowser, no false-pos) \u2192 scrape_fetch \u2192 bridge fetchhtml on dedicated page; selftest ok",
-      "duration_ms": 53
+      "duration_ms": 60
     },
     {
       "name": "Scrapers routed through anti-block fetch",
@@ -2083,7 +2097,7 @@
       "category": "Integration",
       "status": "pass",
       "detail": "toolbar + panel + options all use images/icon-*.png (4 sizes declared)",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "Opal Connect's icon says whether Opal is connected",
@@ -2139,7 +2153,7 @@
       "category": "Storage",
       "status": "pass",
       "detail": "pure+driver+SWR wiring (search/tmdb) + config/settings/startup wired",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "name": "Cache SWR on browse listings",
@@ -2153,7 +2167,7 @@
       "category": "Browse",
       "status": "pass",
       "detail": "infinite scroll wired: Drama/VNDB/Jellyfin/Plex/OPDS/Audiobookshelf/Novels/Radio append next page near bottom; Podcasts left no-op (iTunes Search has no offset cursor); Novels 'readwn' source no-op (POST search, no page field)",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "Plex restored session loads its library",
@@ -2216,7 +2230,7 @@
       "category": "Network",
       "status": "pass",
       "detail": "proxy_url parses, reaches libtorrent, covers peers+trackers, clears when blank",
-      "duration_ms": 1
+      "duration_ms": 0
     },
     {
       "name": "Browse rail groups every source",
@@ -2237,7 +2251,7 @@
       "category": "Video",
       "status": "pass",
       "detail": "Live TV catalog: SQLite (100k) + curated opt-in sources + SWR 24h ingest + nsfw-gated adult",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "Suwayomi source engine",
@@ -2258,21 +2272,21 @@
       "category": "Audio",
       "status": "pass",
       "detail": "Music tab: 4 sources (JioSaavn/Subsonic/Jellyfin/Plex), each pure-routed + inert when unconfigured",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "Music discovery (ListenBrainz + MusicBrainz)",
       "category": "Audio",
       "status": "pass",
       "detail": "Discovery: seeds -> ListenBrainz similar artists -> MusicBrainz studio albums, inert until opt-in",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "Universal search audio fan-out",
       "category": "Search",
       "status": "pass",
       "detail": "Universal search reaches live tv/music/radio/podcasts; cap 96; audio ranked below video",
-      "duration_ms": 1
+      "duration_ms": 2
     },
     {
       "name": "Synced lyrics (lrclib)",
@@ -2412,35 +2426,35 @@
       "category": "Web UI",
       "status": "pass",
       "detail": "typed download actions + live torrent/file controls use one delegated web handler",
-      "duration_ms": 1
+      "duration_ms": 2
     },
     {
       "name": "Web library owns status and episode progress",
       "category": "Web UI",
       "status": "pass",
       "detail": "typed status/watch commands + filters + show episode toggles share the native model",
-      "duration_ms": 1
+      "duration_ms": 2
     },
     {
       "name": "Web shell is installable without caching private media",
       "category": "Web UI",
       "status": "pass",
       "detail": "installable shell caches public assets only and reports offline/reconnect state",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "Web owns the source-plugin catalog lifecycle",
       "category": "Web UI",
       "status": "pass",
       "detail": "stable-id source catalog supports refresh/filter/install/update/remove with real server state",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "Web UI vertical parity wiring",
       "category": "Web UI",
       "status": "pass",
       "detail": "20 verticals wired (nav + section + routes)",
-      "duration_ms": 3
+      "duration_ms": 4
     },
     {
       "name": "Web UI YouTube tab",
@@ -2454,21 +2468,21 @@
       "category": "Web UI",
       "status": "pass",
       "detail": "Live TV: /api/livetv catalog paging + web tab (search, load-more, watch)",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "Web UI add-download + source catalog",
       "category": "Web UI",
       "status": "pass",
       "detail": "Activity add-download (url+magnet) + Setup source catalog install",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "Web UI AI copilot tab + /api/ai route",
       "category": "Web UI",
       "status": "pass",
       "detail": "AI copilot: /api/ai send+poll transcript, phase, playable picks + web tab",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "Web UI Music + Radio tabs and routes",
@@ -2489,7 +2503,7 @@
       "category": "Web UI",
       "status": "pass",
       "detail": "Access page: pw change/reset, revoke-all, token rotate, bind mode+port (all bearer-gated)",
-      "duration_ms": 1
+      "duration_ms": 2
     },
     {
       "name": "Play-latest button: TV show page (desktop + web)",
@@ -2524,42 +2538,42 @@
       "category": "Web UI",
       "status": "pass",
       "detail": "Watching: /api/library (locked snapshot, desktop order) + filter chips + drill-down",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "Movies and shows share one details panel with real metadata",
       "category": "Web UI",
       "status": "pass",
       "detail": "one details panel: /api/movie + /api/tv, media-typed search rows, action row",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "Web Settings page (registry-driven, desktop parity)",
       "category": "Web UI",
       "status": "pass",
       "detail": "Settings: registry-driven /api/settings (validate+reject) + grouped web controls",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "Web Home hub, Plugins manager and Watch Party (desktop parity)",
       "category": "Web UI",
       "status": "pass",
       "detail": "Home hub + Plugins manager + Watch Party wired to /home, /plugins, /party",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "Web UI plays media in the browser (Play here destination)",
       "category": "Web UI",
       "status": "pass",
       "detail": "Play here: direct-play with codec refusal, session-token /stream, 5 play paths routed",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "Torrent per-file streaming + pluggable HLS",
       "category": "Web UI",
       "status": "pass",
       "detail": "Torrent per-file play via /stream + hls.js vendored separately (feature-tested)",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "On-the-fly transcode route",
@@ -2573,7 +2587,7 @@
       "category": "Web UI",
       "status": "pass",
       "detail": "8 feature bundles, 155388 bytes \u2014 node --check clean",
-      "duration_ms": 18
+      "duration_ms": 36
     },
     {
       "name": "Auth core (bcrypt) present + tested",
@@ -2685,7 +2699,7 @@
       "category": "Packaging",
       "status": "pass",
       "detail": "default expands to the two uniquely named Opal media packages",
-      "duration_ms": 1
+      "duration_ms": 4
     },
     {
       "name": "AUR publish runs where makepkg exists",
@@ -2769,7 +2783,7 @@
       "category": "Windows",
       "status": "pass",
       "detail": "all http.Client construction routes through newClient()",
-      "duration_ms": 39
+      "duration_ms": 56
     },
     {
       "name": "http: newClient prewarms TLS state",
@@ -2790,7 +2804,7 @@
       "category": "Windows",
       "status": "pass",
       "detail": "entropy comes from io_global.randomSecure() everywhere",
-      "duration_ms": 33
+      "duration_ms": 54
     },
     {
       "name": "csprng: io_global.randomSecure exists and is fail-closed",
@@ -2811,7 +2825,7 @@
       "category": "Windows",
       "status": "pass",
       "detail": "every sub-add goes through the argv helper",
-      "duration_ms": 31
+      "duration_ms": 54
     },
     {
       "name": "mpv: mpvSubAdd helper uses mpv_command argv form",
@@ -2867,21 +2881,21 @@
       "category": "Windows",
       "status": "pass",
       "detail": "elf-needed.py fails closed on unreadable input",
-      "duration_ms": 9
+      "duration_ms": 23
     },
     {
       "name": "portability: no hardcoded /dev/null in spawned argv",
       "category": "Windows",
       "status": "pass",
       "detail": "every spawned argv uses io_global.devNull()",
-      "duration_ms": 32
+      "duration_ms": 55
     },
     {
       "name": "portability: no raw pkill outside io_global",
       "category": "Windows",
       "status": "pass",
       "detail": "all process kills route through the portable helpers",
-      "duration_ms": 33
+      "duration_ms": 59
     },
     {
       "name": "portability: kill helpers cover all three platforms",
@@ -2909,14 +2923,14 @@
       "category": "Windows",
       "status": "pass",
       "detail": "thumbnails, subtitles and friends use the platform cache dir",
-      "duration_ms": 31
+      "duration_ms": 53
     },
     {
       "name": "storage: page accounts for every store, not just one cache",
       "category": "Storage",
       "status": "pass",
       "detail": "disk usage itemised across caches, downloads and user data",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "storage: sizes are scanned off the render thread",
@@ -2951,7 +2965,7 @@
       "category": "Windows",
       "status": "pass",
       "detail": "all home-directory lookups route through paths.homeDir()",
-      "duration_ms": 31
+      "duration_ms": 53
     },
     {
       "name": "yt-dlp: a present-but-unrunnable binary stands itself down",
@@ -2965,7 +2979,7 @@
       "category": "Windows",
       "status": "pass",
       "detail": "every config path is built from paths.configDir()",
-      "duration_ms": 32
+      "duration_ms": 54
     },
     {
       "name": "lanIp: absolute paths, no cached failure, non-macOS arm",
@@ -2979,7 +2993,7 @@
       "category": "Windows",
       "status": "pass",
       "detail": "signal delivery routes through the portable helpers",
-      "duration_ms": 35
+      "duration_ms": 57
     },
     {
       "name": "Live public tracker list fetched, cached and injected",
@@ -3007,21 +3021,21 @@
       "category": "Sources",
       "status": "pass",
       "detail": "one config file, read by the engine",
-      "duration_ms": 47
+      "duration_ms": 66
     },
     {
       "name": "nova2 engines read the installed source config",
       "category": "Sources",
       "status": "pass",
       "detail": "installed base drives the nova2 engines",
-      "duration_ms": 46
+      "duration_ms": 62
     },
     {
       "name": "Sources fail over to mirror domains",
       "category": "Sources",
       "status": "pass",
       "detail": "ordered failover + last-good memory, both layers",
-      "duration_ms": 44
+      "duration_ms": 63
     },
     {
       "name": "Installed sources are migrated when the manifest corrects an endpoint",
@@ -3042,7 +3056,7 @@
       "category": "Sources",
       "status": "pass",
       "detail": "all 32 manifest bases agree with their engine's own default, so unifying the config cannot disable a working host",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "Every Torznab-compatible source id is actually queried",
@@ -3056,42 +3070,42 @@
       "category": "Sources",
       "status": "pass",
       "detail": "shipped Prowlarr URL returns a parseable torznab feed over HTTP (4 requests); Jackett's path and a non-numeric indexer both 404 as Prowlarr would",
-      "duration_ms": 3
+      "duration_ms": 507
     },
     {
       "name": "EZTV: JSON API backend, sharing the Stremio IMDb lookup",
       "category": "Sources",
       "status": "pass",
       "detail": "EZTV served from its JSON API in one request, reusing the Stremio IMDb lookup; inert until the source is installed",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "Resolver: results go to a sink, so a warm cannot clobber a search",
       "category": "Sources",
       "status": "pass",
       "detail": "results routed through a per-thread sink; warm fills the cache with the same ranking and encoder, never the live list",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "nova2 engine catalog: versions.txt complete and matching",
       "category": "Torrents",
       "status": "pass",
       "detail": "23 plugins, every one versioned and matching its header (1 quarantined non-plugin)",
-      "duration_ms": 0
+      "duration_ms": 2
     },
     {
       "name": "nova2 engine catalog: every plugin satisfies the import contract",
       "category": "Torrents",
       "status": "pass",
       "detail": "23 plugins import and expose their capabilities",
-      "duration_ms": 51
+      "duration_ms": 86
     },
     {
       "name": "nova2 engine catalog: plugins declare url + name + categories",
       "category": "Torrents",
       "status": "pass",
       "detail": "every plugin declares an absolute url, name and supported_categories; 1 known instance-attr-only engine",
-      "duration_ms": 1
+      "duration_ms": 3
     },
     {
       "name": "nova2 engine catalog: no engine is orphaned by the install gate",
@@ -3105,21 +3119,21 @@
       "category": "Torrents",
       "status": "pass",
       "detail": "unresolvable magnets skip their row; feed() survives",
-      "duration_ms": 9
+      "duration_ms": 6
     },
     {
       "name": "nova2 engine catalog: nothing prints to stdout but results",
       "category": "Torrents",
       "status": "pass",
       "detail": "all 23 engines emit only via prettyPrinter",
-      "duration_ms": 17
+      "duration_ms": 31
     },
     {
       "name": "The anti-block fallback does not depend on the Web Remote toggle",
       "category": "Torrents",
       "status": "pass",
       "detail": "loopback-only /api/scrape runs regardless of Web Remote; client prefers 41596 and falls back to 41595",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "The stall watchdog runs off the UI thread",
@@ -3133,7 +3147,7 @@
       "category": "Torrents",
       "status": "pass",
       "detail": "all 23 engines fetch through helpers.retrieve_url \u2014 one choke point, no bypasses",
-      "duration_ms": 1
+      "duration_ms": 2
     },
     {
       "name": "one337x/uindex: the parsers match the markup the sites actually serve",
@@ -3189,7 +3203,7 @@
       "category": "Torrents",
       "status": "pass",
       "detail": "all terms required; empty terms dropped; single-term search intact",
-      "duration_ms": 1
+      "duration_ms": 3
     },
     {
       "name": "torrents: adding before the engine is up says so",
@@ -3231,14 +3245,14 @@
       "category": "Parity",
       "status": "pass",
       "detail": "trakt/suwayomi/about exposed, tokens and the updater withheld",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "Web API: live tv sources + web ui kill switch",
       "category": "Parity",
       "status": "pass",
       "detail": "live tv sources validated against the table; kill switch confirm-gated",
-      "duration_ms": 0
+      "duration_ms": 1
     },
     {
       "name": "Web UI: the source catalog never truncates silently",
@@ -3259,7 +3273,7 @@
       "category": "Parity",
       "status": "pass",
       "detail": "Setup folds by section; torrent pct reports one decimal",
-      "duration_ms": 0
+      "duration_ms": 1
     }
   ]
 }


### PR DESCRIPTION
## Summary

- **Canonical app identity**: new `core/app_meta.zig` derives the version from `build.zig.zon` via build_options; every user agent (subtitles, resolver, search, youtube, comics) and `/api/host` now come from it. Removed the hand-maintained "Opal/1.0" / "0.1.2" literals. Development builds report the exact declared version (documented in CONTRIBUTING.md).
- **Race-free remote file serving** (`/stream`, `/vtt`, `/transcode`): files are opened through a no-follow `openat` walk from an already-open downloads-root dir (`remote_stream_path.zig`), so a symlink swapped between validation and open cannot escape the root. ffmpeg transcode input is piped over stdin instead of passing the request-controlled path. `safeRelPath` additionally rejects backslash, colon, empty, "." and ".." components.
- **io_global**: `Child.takeStdin` transfers piped-stdin ownership so wait()/kill() can't close a descriptor a feeder thread is using.
- **Watching page redesign**: progress-first layout — Up next rail (active titles) above the saved library grid; segmented TYPE/PROGRESS filters via themed `components.segment`; actionable empty states (Browse / Clear filters); local filenames cleaned via new `core/display_name_pure.zig`.

## Test plan

- [x] `zig build test` — clean
- [x] `python3 tests/test_features.py` — 411 passed, 8 skipped; the only fail is pre-existing (AI-attribution trailer on commit 3a06783, already in history)
- Updated stale checks in test_stability.py / test_scrape_fetch.py that pinned the removed UA literals